### PR TITLE
Migrate file text handling from raw strings to ropey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,6 +499,7 @@ dependencies = [
  "crossterm 0.29.0",
  "oxid-lsp",
  "ratatui",
+ "ropey",
 ]
 
 [[package]]
@@ -610,6 +611,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "ropey"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93411e420bcd1a75ddd1dc3caf18c23155eda2c090631a85af21ba19e97093b5"
+dependencies = [
+ "smallvec",
+ "str_indices",
 ]
 
 [[package]]
@@ -751,6 +762,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "str_indices"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08889ec5408683408db66ad89e0e1f93dff55c73a4ccc71c427d5b277ee47e6"
 
 [[package]]
 name = "strsim"

--- a/oxid/Cargo.toml
+++ b/oxid/Cargo.toml
@@ -4,7 +4,10 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+anyhow.workspace = true
+
 crossterm = "0.29.0"
 ratatui = { version = "0.29.0", features = ["all-widgets"] }
+ropey = "1.6.1"
+
 oxid-lsp = { path = "../oxid-lsp"}
-anyhow.workspace = true

--- a/oxid/src/app.rs
+++ b/oxid/src/app.rs
@@ -28,7 +28,7 @@ impl App {
             quitting: false,
             buffers,
             registers: HashMap::from([(String::from("default"), String::new())]),
-            debug_mode: true,
+            debug_mode: false,
         }
     }
 

--- a/oxid/src/app.rs
+++ b/oxid/src/app.rs
@@ -218,7 +218,7 @@ impl App {
                                     if !vis {
                                         if let Some(paste_string) = self.registers.get("default") {
                                             if !paste_string.is_empty() {
-                                                self.buffers[0].paste(paste_string.to_string());
+                                                self.buffers[0].paste(paste_string.to_owned());
                                             }
                                         }
                                     }

--- a/oxid/src/buffer/core.rs
+++ b/oxid/src/buffer/core.rs
@@ -1,12 +1,11 @@
 use ropey::Rope;
 
-use super::types::{BufferPosition, FileLine, Selection};
+use super::types::{BufferPosition, Selection};
 
 pub const STATUSBAR_SPACE: usize = 1;
 
 pub struct Buffer {
     pub file_path: Option<String>,
-    // pub file_lines: Vec<FileLine>,
     pub file_text: Rope,
     pub viewport_width: usize,
     pub viewport_height: usize,
@@ -28,13 +27,6 @@ impl Buffer {
         let numbar_space = file_text.lines().count().to_string().len() + 1;
         Buffer {
             file_path,
-            // file_lines: file_text
-            //     .lines()
-            //     .map(|l| FileLine {
-            //         content: l.to_string(),
-            //         length: l.len(),
-            //     })
-            //     .collect(),
             file_text,
             viewport_width: viewport_width - numbar_space,
             viewport_height: viewport_height - STATUSBAR_SPACE,

--- a/oxid/src/buffer/core.rs
+++ b/oxid/src/buffer/core.rs
@@ -1,10 +1,13 @@
+use ropey::Rope;
+
 use super::types::{BufferPosition, FileLine, Selection};
 
 pub const STATUSBAR_SPACE: usize = 1;
 
 pub struct Buffer {
     pub file_path: Option<String>,
-    pub file_lines: Vec<FileLine>,
+    // pub file_lines: Vec<FileLine>,
+    pub file_text: Rope,
     pub viewport_width: usize,
     pub viewport_height: usize,
     pub vertical_scroll: usize,
@@ -18,20 +21,21 @@ pub struct Buffer {
 impl Buffer {
     pub fn new(
         file_path: Option<String>,
-        file_text: String,
+        file_text: Rope,
         viewport_width: usize,
         viewport_height: usize,
     ) -> Self {
         let numbar_space = file_text.lines().count().to_string().len() + 1;
         Buffer {
             file_path,
-            file_lines: file_text
-                .lines()
-                .map(|l| FileLine {
-                    content: l.to_string(),
-                    length: l.len(),
-                })
-                .collect(),
+            // file_lines: file_text
+            //     .lines()
+            //     .map(|l| FileLine {
+            //         content: l.to_string(),
+            //         length: l.len(),
+            //     })
+            //     .collect(),
+            file_text,
             viewport_width: viewport_width - numbar_space,
             viewport_height: viewport_height - STATUSBAR_SPACE,
             vertical_scroll: 0,

--- a/oxid/src/buffer/editing.rs
+++ b/oxid/src/buffer/editing.rs
@@ -4,15 +4,15 @@ impl Buffer {
     pub fn paste(&mut self, paste_string: String) {
         let curr_line = self.current_position.line;
         let curr_char = self.current_position.character - self.numbar_space;
-        
+
         let curr_string = self.file_text.line(curr_line).to_string();
-        
+
         // Ensure curr_char doesn't exceed the line length
         let safe_curr_char = curr_char.min(curr_string.len());
-        
+
         let start_until_cursor = &curr_string[0..safe_curr_char];
         let rest_original_string = &curr_string[safe_curr_char..];
-        
+
         let newlines: Vec<_> = paste_string.lines().collect();
 
         // Handle empty paste string
@@ -29,7 +29,7 @@ impl Buffer {
             let line_len = self.file_text.line(curr_line).len_chars();
             let start_line_char = self.file_text.line_to_char(curr_line);
             let end_line_char = start_line_char + line_len;
-            
+
             if start_line_char <= end_line_char && end_line_char <= self.file_text.len_chars() {
                 self.file_text.remove(start_line_char..end_line_char);
                 self.file_text.insert(start_line_char, &new_str);
@@ -42,21 +42,10 @@ impl Buffer {
 
             let line_len = self.file_text.line(curr_line).len_chars();
             let start_line_char = self.file_text.line_to_char(curr_line);
-            
-            // For the last line, handle carefully
-            let end_line_char = if curr_line == self.file_text.len_lines() - 1 {
-                // Last line, then include all characters
-                start_line_char + line_len
-            } else {
-                // Not last line, then exclude the newline character
-                start_line_char + line_len.saturating_sub(1)
-            };
+            let end_line_char = start_line_char + line_len;
 
-            // Safety check for the range
-            if start_line_char <= end_line_char && end_line_char <= self.file_text.len_chars() {
-                self.file_text.remove(start_line_char..end_line_char);
-                self.file_text.insert(start_line_char, &new_text);
-            }
+            self.file_text.remove(start_line_char..end_line_char);
+            self.file_text.insert(start_line_char, &new_text);
         }
         self.update_numbar_space();
         self.ensure_cursor_visible();

--- a/oxid/src/buffer/editing.rs
+++ b/oxid/src/buffer/editing.rs
@@ -28,16 +28,8 @@ impl Buffer {
 
             let line_len = self.file_text.line(curr_line).len_chars();
             let start_line_char = self.file_text.line_to_char(curr_line);
+            let end_line_char = start_line_char + line_len;
             
-            // For the last line, we need to be careful about the range
-            let end_line_char = if curr_line == self.file_text.len_lines() - 1 {
-                // This is last line, don't include newline character if it doesn't exist
-                start_line_char + line_len
-            } else {
-                // This is not last line, include up to but not including the newline
-                start_line_char + line_len.saturating_sub(1)
-            };
-
             if start_line_char <= end_line_char && end_line_char <= self.file_text.len_chars() {
                 self.file_text.remove(start_line_char..end_line_char);
                 self.file_text.insert(start_line_char, &new_str);

--- a/oxid/src/buffer/editing.rs
+++ b/oxid/src/buffer/editing.rs
@@ -84,47 +84,26 @@ impl Buffer {
         }
 
         if curr_char > 0 {
-            // Regular backspace: delete the character just before the cursor
+            // Regular backspace, just delete the character before the cursor
             self.file_text
                 .remove(line_start_char + curr_char - 1..line_start_char + curr_char);
             self.current_position.character = self.current_position.character.saturating_sub(1);
         } else {
-            // We're at the start of a line -> merge with previous line
+            // We're at the start of a line, merge with previous line
             let prev_line = curr_line - 1;
             let prev_line_len = self.file_text.line(prev_line).len_chars() -1;
 
-            // Remove the line break between prev_line and curr_line
+            // Remove the line break
             let prev_line_end = self.file_text.line_to_char(prev_line) + prev_line_len;
             let curr_line_start = line_start_char;
             self.file_text.remove(prev_line_end..curr_line_start);
 
-            // Update cursor: move to end of previous line
+            // Update cursor and move to end of previous line
             self.current_position.line = prev_line;
             self.current_position.character = prev_line_len + self.numbar_space;
         }
 
         self.ensure_cursor_visible();
-        // let curr_line = self.current_position.line;
-        // let curr_char = self.current_position.character - self.numbar_space;
-        // let line_to_char = self.file_text.line_to_char(curr_line);
-        //
-        // if curr_line == 0 && curr_char == 0 {
-        //     return;
-        // }
-        //
-        // // TODO: Deleting in same line works, but need to move cursor to other lines if deleting
-        // // goes to above line.
-        // self.file_text.remove(
-        //     line_to_char.saturating_add(curr_char).saturating_sub(1)
-        //         ..line_to_char.saturating_add(curr_char),
-        // );
-        // self.current_position.character = self.current_position.character.saturating_sub(1);
-        // if self.current_position.character - self.numbar_space == 0 {
-        //     self.current_position.line = curr_line.saturating_sub(1);
-        //     self.current_position.character =
-        //         self.file_text.line(self.current_position.line).len_chars() + self.numbar_space;
-        // }
-        // self.ensure_cursor_visible();
     }
 
     pub fn enter_key(&mut self) {
@@ -137,50 +116,9 @@ impl Buffer {
         self.current_position.line = self.current_position.line.saturating_add(1);
         self.current_position.character = self.numbar_space;
         self.ensure_cursor_visible();
-        // let curr_line = self.file_lines[self.current_position.line].clone();
-        // let current_character = self.current_position.character;
-        // // If cursor is at the end of the line, just include empty line below.
-        // if current_character - self.numbar_space == curr_line.length {
-        //     self.file_lines.insert(
-        //         self.current_position.line + 1,
-        //         FileLine {
-        //             content: String::from(""),
-        //             length: 0,
-        //         },
-        //     );
-        //     self.update_numbar_space();
-        //     self.current_position.line = self.current_position.line.saturating_add(1);
-        //     self.current_position.character = self.numbar_space;
-        // } else if current_character >= self.numbar_space && current_character < curr_line.length {
-        //     // If cursor is anywhere between the line, move cursor + forward to next line.
-        //     // So basically, current line should be line[0..cursor] and next line should be
-        //     // line[cursor..]
-        //     self.file_lines[self.current_position.line].content =
-        //         curr_line.content[0..current_character - self.numbar_space].to_string();
-        //
-        //     let new_line_content =
-        //         curr_line.content[current_character - self.numbar_space..].to_string();
-        //
-        //     self.file_lines.insert(
-        //         self.current_position.line + 1,
-        //         FileLine {
-        //             content: new_line_content.clone(),
-        //             length: new_line_content.len(),
-        //         },
-        //     );
-        //     self.update_numbar_space();
-        //     self.current_position.line = self.current_position.line.saturating_add(1);
-        //     self.current_position.character = self.numbar_space;
-        // }
-        // self.ensure_cursor_visible();
     }
 
     pub fn save_file(&self) -> anyhow::Result<()> {
-        // let lines_vec: Vec<_> = self
-        //     .file_lines
-        //     .iter()
-        //     .map(|fl| fl.content.clone())
-        //     .collect();
         let text = self.file_text.to_string();
         if let Some(filepath) = &self.file_path {
             std::fs::write(filepath, text)?;

--- a/oxid/src/buffer/editing.rs
+++ b/oxid/src/buffer/editing.rs
@@ -5,10 +5,12 @@ impl Buffer {
     pub fn paste(&mut self, paste_string: String) {
         let curr_line = self.current_position.line;
         let curr_char = self.current_position.character - self.numbar_space;
-        let curr_string = self.file_lines[curr_line].content.clone();
+        // let curr_string = self.file_lines[curr_line].content.clone();
+        let curr_string = self.file_text.line(curr_line).to_string();
         let start_until_cursor = &curr_string[0..curr_char];
         let rest_original_string = &curr_string[curr_char..];
-        let newlines: Vec<_> = paste_string.lines().collect();
+        let binding = paste_string.to_string();
+        let newlines: Vec<_> = binding.lines().collect();
 
         // We only handle two cases, if len == 1 or len > 1. We should never receive an empty
         // pastestring here.
@@ -16,46 +18,61 @@ impl Buffer {
             // If we have len == 1 this means there were no newlines and we can just append on
             // cursor position and don't have to handle newlines after.
             let mut new_str = String::from(start_until_cursor);
-            new_str.push_str(&paste_string);
+            new_str.push_str(&paste_string.to_string());
             new_str.push_str(rest_original_string);
-            self.file_lines[curr_line].length = new_str.len();
-            self.file_lines[curr_line].content = new_str;
+            // self.file_lines[curr_line].length = new_str.len();
+            // self.file_lines[curr_line].content = new_str;
+            let line_len = self.file_text.line(curr_line).len_chars();
+            let start_line_char = self.file_text.line_to_char(curr_line);
+            let end_line_char = start_line_char + line_len - 1;
+            self.file_text.remove(start_line_char..end_line_char);
+            self.file_text.insert(start_line_char, &new_str);
         } else if newlines.len() > 1 {
             // If we enter here, means we need to do multiline selection handling.
             // Update the current line with the first part
             let mut first_line = String::from(start_until_cursor);
             first_line.push_str(newlines[0]);
-            self.file_lines[curr_line].length = first_line.len();
-            self.file_lines[curr_line].content = first_line;
+            // self.file_lines[curr_line].length = first_line.len();
+            // self.file_lines[curr_line].content = first_line;
+            let line_len = self.file_text.line(curr_line).len_chars();
+            let start_line_char = self.file_text.line_to_char(curr_line);
+            let end_line_char = start_line_char + line_len - 1;
+            self.file_text.remove(start_line_char..end_line_char);
+            self.file_text.insert(start_line_char, &first_line);
 
             // Insert middle lines (if any)
             for (i, str_text) in newlines[1..newlines.len() - 1].iter().enumerate() {
-                self.file_lines.insert(
-                    curr_line + i + 1,
-                    FileLine {
-                        content: str_text.to_string(),
-                        length: str_text.len(),
-                    },
-                );
+                // self.file_lines.insert(
+                //     curr_line + i + 1,
+                //     FileLine {
+                //         content: str_text.to_string(),
+                //         length: str_text.len(),
+                //     },
+                // );
+                self.file_text.insert(curr_line + i + 1, &str_text);
             }
 
             // Handle the last line
             let last_newline = newlines[newlines.len() - 1];
             let mut last_line = String::from(last_newline);
             last_line.push_str(rest_original_string);
-            self.file_lines.insert(
-                curr_line + newlines.len() - 1,
-                FileLine {
-                    content: last_line.clone(),
-                    length: last_line.len(),
-                },
-            );
+            // self.file_lines.insert(
+            //     curr_line + newlines.len() - 1,
+            //     FileLine {
+            //         content: last_line.clone(),
+            //         length: last_line.len(),
+            //     },
+            // );
+            self.file_text
+                .insert(curr_line + newlines.len() - 1, &last_line);
         }
     }
     pub fn update_numbar_space(&mut self) {
-        let numbar_space = self.file_lines.len().to_string().len() + 1;
+        // let numbar_space = self.file_lines.len().to_string().len() + 1;
+        let numbar_space = self.file_text.len_lines().to_string().len() + 1;
         if self.numbar_space != numbar_space {
-            self.numbar_space = self.file_lines.len().to_string().len() + 1;
+            // self.numbar_space = self.file_lines.len().to_string().len() + 1;
+            self.numbar_space = self.file_text.len_lines().to_string().len() + 1;
         }
     }
 
@@ -63,114 +80,137 @@ impl Buffer {
         // TODO: Need to handle edge case where line is new line.
         // Probably gonna have to optimize this later as there are many clones.
         // In the future, handling '\n' or '<CR>' will be tricky.
+        
+        let line = self.current_position.line;
+        let character = self.current_position.character - self.numbar_space;
+        let mut char_idx = self.file_text.line_to_char(line);
+        char_idx = char_idx.saturating_add(character);
+        self.file_text.insert_char(char_idx, ch);
+        self.update_numbar_space();
+        self.current_position.character = self.current_position.character.saturating_add(1);
 
-        let mut curr_line = self.file_lines[self.current_position.line].content.clone();
-        let insert_index = self.current_position.character - self.numbar_space;
-        if insert_index <= curr_line.len() {
-            curr_line.insert(insert_index, ch);
-            self.update_numbar_space();
-            self.file_lines[self.current_position.line].content = curr_line.clone();
-            self.file_lines[self.current_position.line].length = curr_line.len();
-            self.current_position.character = self.current_position.character.saturating_add(1);
-        }
+        // let mut curr_line = self.file_lines[self.current_position.line].content.clone();
+        // let insert_index = self.current_position.character - self.numbar_space;
+        // if insert_index <= curr_line.len() {
+        //     curr_line.insert(insert_index, ch);
+        //     self.update_numbar_space();
+        //     self.file_lines[self.current_position.line].content = curr_line.clone();
+        //     self.file_lines[self.current_position.line].length = curr_line.len();
+        //     self.current_position.character = self.current_position.character.saturating_add(1);
+        // }
         self.ensure_cursor_visible();
     }
 
     pub fn remove_char(&mut self) {
-        // Probably gonna have to optimize this later as there are many clones.
-        let mut curr_line = self.file_lines[self.current_position.line].content.clone();
-
-        // If current position is and only if is bigger than the numbar, delete it.
-        if self.current_position.character > self.numbar_space {
-            let string_index = self.current_position.character - 1 - self.numbar_space;
-            if string_index < curr_line.len() {
-                curr_line.remove(string_index);
-                self.update_numbar_space();
-                self.file_lines[self.current_position.line].content = curr_line.clone();
-                self.file_lines[self.current_position.line].length = curr_line.len();
-                self.current_position.character = self.current_position.character.saturating_sub(1);
-            }
-        }
-
-        // If current pos is just after the numbar, means we're deleting entire line.
-        if self.current_position.character == self.numbar_space && self.current_position.line > 0 {
-            let current_line_index = self.current_position.line;
-
-            // If it's empty, should just delete the line and move cursor.
-            if self.file_lines[current_line_index].content.is_empty() {
-                self.file_lines.remove(current_line_index);
-                self.update_numbar_space();
-                self.current_position.line = self.current_position.line.saturating_sub(1);
-                self.current_position.character =
-                    self.file_lines[current_line_index - 1].length + self.numbar_space;
-            }
-            // If it's not empty, should join the current linestring with the previous unless it's the
-            // first line, and move cursor to last char of previous line.
-            else {
-                let line = self.file_lines[current_line_index].clone();
-                let mut top_line = self.file_lines[current_line_index - 1].clone();
-                let top_line_old_len = top_line.length;
-
-                top_line.content = top_line.content + &line.content;
-                top_line.length = top_line.content.len();
-                self.file_lines[current_line_index - 1] = top_line;
-                self.file_lines.remove(current_line_index);
-                self.update_numbar_space();
-
-                self.current_position.line = self.current_position.line.saturating_sub(1);
-                self.current_position.character = top_line_old_len + self.numbar_space;
-            }
-        }
-        self.ensure_cursor_visible();
+        let curr_line = self.current_position.line;
+        let curr_char = self.current_position.character - self.numbar_space;
+        let mut char_range = self.file_text.line_to_char(curr_line);
+        char_range = char_range.saturating_add(curr_char);
+        self.file_text.remove(char_range..char_range);
+        // // Probably gonna have to optimize this later as there are many clones.
+        // let mut curr_line = self.file_lines[self.current_position.line].content.clone();
+        //
+        // // If current position is and only if is bigger than the numbar, delete it.
+        // if self.current_position.character > self.numbar_space {
+        //     let string_index = self.current_position.character - 1 - self.numbar_space;
+        //     if string_index < curr_line.len() {
+        //         curr_line.remove(string_index);
+        //         self.update_numbar_space();
+        //         self.file_lines[self.current_position.line].content = curr_line.clone();
+        //         self.file_lines[self.current_position.line].length = curr_line.len();
+        //         self.current_position.character = self.current_position.character.saturating_sub(1);
+        //     }
+        // }
+        //
+        // // If current pos is just after the numbar, means we're deleting entire line.
+        // if self.current_position.character == self.numbar_space && self.current_position.line > 0 {
+        //     let current_line_index = self.current_position.line;
+        //
+        //     // If it's empty, should just delete the line and move cursor.
+        //     if self.file_lines[current_line_index].content.is_empty() {
+        //         self.file_lines.remove(current_line_index);
+        //         self.update_numbar_space();
+        //         self.current_position.line = self.current_position.line.saturating_sub(1);
+        //         self.current_position.character =
+        //             self.file_lines[current_line_index - 1].length + self.numbar_space;
+        //     }
+        //     // If it's not empty, should join the current linestring with the previous unless it's the
+        //     // first line, and move cursor to last char of previous line.
+        //     else {
+        //         let line = self.file_lines[current_line_index].clone();
+        //         let mut top_line = self.file_lines[current_line_index - 1].clone();
+        //         let top_line_old_len = top_line.length;
+        //
+        //         top_line.content = top_line.content + &line.content;
+        //         top_line.length = top_line.content.len();
+        //         self.file_lines[current_line_index - 1] = top_line;
+        //         self.file_lines.remove(current_line_index);
+        //         self.update_numbar_space();
+        //
+        //         self.current_position.line = self.current_position.line.saturating_sub(1);
+        //         self.current_position.character = top_line_old_len + self.numbar_space;
+        //     }
+        // }
+        // self.ensure_cursor_visible();
     }
 
     pub fn enter_key(&mut self) {
-        let curr_line = self.file_lines[self.current_position.line].clone();
-        let current_character = self.current_position.character;
-        // If cursor is at the end of the line, just include empty line below.
-        if current_character - self.numbar_space == curr_line.length {
-            self.file_lines.insert(
-                self.current_position.line + 1,
-                FileLine {
-                    content: String::from(""),
-                    length: 0,
-                },
-            );
-            self.update_numbar_space();
-            self.current_position.line = self.current_position.line.saturating_add(1);
-            self.current_position.character = self.numbar_space;
-        } else if current_character >= self.numbar_space && current_character < curr_line.length {
-            // If cursor is anywhere between the line, move cursor + forward to next line.
-            // So basically, current line should be line[0..cursor] and next line should be
-            // line[cursor..]
-            self.file_lines[self.current_position.line].content =
-                curr_line.content[0..current_character - self.numbar_space].to_string();
-
-            let new_line_content =
-                curr_line.content[current_character - self.numbar_space..].to_string();
-
-            self.file_lines.insert(
-                self.current_position.line + 1,
-                FileLine {
-                    content: new_line_content.clone(),
-                    length: new_line_content.len(),
-                },
-            );
-            self.update_numbar_space();
-            self.current_position.line = self.current_position.line.saturating_add(1);
-            self.current_position.character = self.numbar_space;
-        }
+        let line = self.current_position.line;
+        let character = self.current_position.character - self.numbar_space;
+        let mut char_idx = self.file_text.line_to_char(line);
+        char_idx = char_idx.saturating_add(character);
+        self.file_text.insert(char_idx, "\n");
+        self.update_numbar_space();
+        self.current_position.line = self.current_position.line.saturating_add(1);
+        self.current_position.character = self.numbar_space;
         self.ensure_cursor_visible();
+        // let curr_line = self.file_lines[self.current_position.line].clone();
+        // let current_character = self.current_position.character;
+        // // If cursor is at the end of the line, just include empty line below.
+        // if current_character - self.numbar_space == curr_line.length {
+        //     self.file_lines.insert(
+        //         self.current_position.line + 1,
+        //         FileLine {
+        //             content: String::from(""),
+        //             length: 0,
+        //         },
+        //     );
+        //     self.update_numbar_space();
+        //     self.current_position.line = self.current_position.line.saturating_add(1);
+        //     self.current_position.character = self.numbar_space;
+        // } else if current_character >= self.numbar_space && current_character < curr_line.length {
+        //     // If cursor is anywhere between the line, move cursor + forward to next line.
+        //     // So basically, current line should be line[0..cursor] and next line should be
+        //     // line[cursor..]
+        //     self.file_lines[self.current_position.line].content =
+        //         curr_line.content[0..current_character - self.numbar_space].to_string();
+        //
+        //     let new_line_content =
+        //         curr_line.content[current_character - self.numbar_space..].to_string();
+        //
+        //     self.file_lines.insert(
+        //         self.current_position.line + 1,
+        //         FileLine {
+        //             content: new_line_content.clone(),
+        //             length: new_line_content.len(),
+        //         },
+        //     );
+        //     self.update_numbar_space();
+        //     self.current_position.line = self.current_position.line.saturating_add(1);
+        //     self.current_position.character = self.numbar_space;
+        // }
+        // self.ensure_cursor_visible();
     }
 
     pub fn save_file(&self) -> anyhow::Result<()> {
-        let lines_vec: Vec<_> = self
-            .file_lines
-            .iter()
-            .map(|fl| fl.content.clone())
-            .collect();
+        // let lines_vec: Vec<_> = self
+        //     .file_lines
+        //     .iter()
+        //     .map(|fl| fl.content.clone())
+        //     .collect();
+        let text = self.file_text.to_string();
         if let Some(filepath) = &self.file_path {
-            std::fs::write(filepath.clone(), lines_vec.join("\n"))?;
+            std::fs::write(filepath, text)?;
         } else {
             anyhow::bail!("No filepath provided, cannot save file...")
         }

--- a/oxid/src/buffer/movement.rs
+++ b/oxid/src/buffer/movement.rs
@@ -29,7 +29,6 @@ impl Buffer {
     }
     pub fn move_cursor_end_line(&mut self) {
         self.current_position.character =
-            // self.file_text[self.current_position.line].length + self.numbar_space;
             (self.file_text.line(self.current_position.line).len_chars() - 1) + self.numbar_space;
     }
 
@@ -102,19 +101,16 @@ impl Buffer {
         self.current_position.line = self.current_position.line.saturating_sub(1);
         // Edge case where when going up the line is empty line. Then put cursor
         // after numbar.
-        // if self.file_lines[self.current_position.line].length == 0 {
         if self.file_text.line(self.current_position.line).len_chars() == 0 {
             self.current_position.character = self.numbar_space;
         }
         // If current char after going up would be bigger than the new line's
         // length, put it on max character of the line.
         else if self.current_position.character
-            // > self.file_lines[self.current_position.line].length + self.numbar_space
             > self.file_text.line(self.current_position.line).len_chars() + self.numbar_space
         {
             // -1 because lines start at 0 and length is always bigger.
             self.current_position.character =
-                // self.file_lines[self.current_position.line].length + self.numbar_space - 1;
                 self.file_text.line(self.current_position.line).len_chars() + self.numbar_space - 1;
         }
         self.ensure_cursor_visible();
@@ -178,7 +174,6 @@ impl Buffer {
         }
 
         // Try next lines
-        // for next_line_idx in (line_idx + 1)..self.file_lines.len() {
         for next_line_idx in (line_idx + 1)..self.file_text.len_lines() {
             if let Some(chars) = self.get_line_chars(next_line_idx) {
                 if chars.is_empty() {
@@ -314,7 +309,6 @@ impl Buffer {
         }
 
         // Try next lines
-        // for next_line_idx in (line_idx + 1)..self.file_lines.len() {
         for next_line_idx in (line_idx + 1)..self.file_text.len_lines() {
             if let Some(chars) = self.get_line_chars(next_line_idx) {
                 if chars.is_empty() {
@@ -335,9 +329,6 @@ impl Buffer {
     }
 
     fn get_line_chars(&self, line_idx: usize) -> Option<Vec<char>> {
-        // self.file_lines
-        //     .get(line_idx)
-        //     .map(|line| line.content.chars().collect())
         Some(self.file_text.line(line_idx).chars().collect())
     }
 

--- a/oxid/src/buffer/movement.rs
+++ b/oxid/src/buffer/movement.rs
@@ -77,13 +77,10 @@ impl Buffer {
     }
 
     pub fn move_cursor_down(&mut self) {
-        // If current line is bigger than length of lines vector - 1, limit
-        // it to last line available. Must be len(vec) - 1 because lines start at
-        // 0.
+        // If current line is bigger or eq than num of total lines, limit
+        // it to last line available. Must be len_lines() - 1 because lines start at 0.
         self.current_position.line = {
-            // if self.current_position.line >= (self.file_lines.len() - 1) {
-            if self.current_position.line > (self.file_text.len_lines() - 1) {
-                // self.file_lines.len() - 1
+            if self.current_position.line >= (self.file_text.len_lines() - 1) {
                 self.file_text.len_lines() - 1
             } else {
                 self.current_position.line.saturating_add(1)
@@ -92,19 +89,15 @@ impl Buffer {
 
         // Edge case where when going down, the line is empty line. Then put cursor
         // right after numbar.
-        // if self.file_lines[self.current_position.line].length == 0 {
         if self.file_text.line(self.current_position.line).len_chars() == 0 {
             self.current_position.character = self.numbar_space;
         }
         // If current char after going down would be bigger than the new line's
         // length, put it on max character of the line.
         else if self.current_position.character
-            // > self.file_lines[self.current_position.line].length + self.numbar_space
             > self.file_text.line(self.current_position.line).len_chars() + self.numbar_space
         {
-            // -1 because lines start at 0 and length is always bigger.
             self.current_position.character =
-                // self.file_lines[self.current_position.line].length + self.numbar_space - 1;
                 self.file_text.line(self.current_position.line).len_chars() + self.numbar_space - 1;
         }
         self.ensure_cursor_visible();

--- a/oxid/src/buffer/movement.rs
+++ b/oxid/src/buffer/movement.rs
@@ -29,35 +29,43 @@ impl Buffer {
     }
     pub fn move_cursor_end_line(&mut self) {
         self.current_position.character =
-            self.file_lines[self.current_position.line].length + self.numbar_space;
+            // self.file_text[self.current_position.line].length + self.numbar_space;
+            self.file_text.line(self.current_position.line).len_chars() + self.numbar_space;
     }
 
     pub fn scroll_up(&mut self, lines: usize) {
         self.vertical_scroll = self.vertical_scroll.saturating_sub(lines);
         self.current_position.line = self.current_position.line.saturating_sub(lines);
-        if self.file_lines[self.current_position.line].length
+        // if self.file_lines[self.current_position.line].length
+        if self.file_text.line(self.current_position.line).len_chars()
             < self.current_position.character - self.numbar_space
         {
             self.current_position.character =
-                self.file_lines[self.current_position.line].length + self.numbar_space;
+                // self.file_lines[self.current_position.line].length + self.numbar_space;
+                self.file_text.line(self.current_position.line).len_chars() + self.numbar_space;
         }
     }
 
     pub fn scroll_down(&mut self, lines: usize) {
-        let max_scroll = (self.file_lines.len()).saturating_sub(self.viewport_height);
+        // let max_scroll = (self.file_lines.len()).saturating_sub(self.viewport_height);
+        let max_scroll = (self.file_text.len_lines()).saturating_sub(self.viewport_height);
         self.vertical_scroll = std::cmp::min(self.vertical_scroll + lines, max_scroll);
         self.current_position.line = {
-            if self.current_position.line.saturating_add(lines) > self.file_lines.len() {
-                self.file_lines.len() - 1 // Respect the status line
+            // if self.current_position.line.saturating_add(lines) > self.file_lines.len() {
+            if self.current_position.line.saturating_add(lines) > self.file_text.len_lines() {
+                // self.file_lines.len() - 1 // Respect the status line
+                self.file_text.len_lines() - 1 // Respect the status line
             } else {
                 self.current_position.line.saturating_add(lines)
             }
         };
-        if self.file_lines[self.current_position.line].length
+        // if self.file_lines[self.current_position.line].length
+        if self.file_text.line(self.current_position.line).len_chars()
             < self.current_position.character - self.numbar_space
         {
             self.current_position.character =
-                self.file_lines[self.current_position.line].length + self.numbar_space;
+                // self.file_lines[self.current_position.line].length + self.numbar_space;
+                self.file_text.line(self.current_position.line).len_chars() + self.numbar_space;
         }
     }
 
@@ -73,8 +81,10 @@ impl Buffer {
         // it to last line available. Must be len(vec) - 1 because lines start at
         // 0.
         self.current_position.line = {
-            if self.current_position.line >= (self.file_lines.len() - 1) {
-                self.file_lines.len() - 1
+            // if self.current_position.line >= (self.file_lines.len() - 1) {
+            if self.current_position.line > (self.file_text.len_lines() - 1) {
+                // self.file_lines.len() - 1
+                self.file_text.len_lines() - 1
             } else {
                 self.current_position.line.saturating_add(1)
             }
@@ -82,17 +92,20 @@ impl Buffer {
 
         // Edge case where when going down, the line is empty line. Then put cursor
         // right after numbar.
-        if self.file_lines[self.current_position.line].length == 0 {
+        // if self.file_lines[self.current_position.line].length == 0 {
+        if self.file_text.line(self.current_position.line).len_chars() == 0 {
             self.current_position.character = self.numbar_space;
         }
         // If current char after going down would be bigger than the new line's
         // length, put it on max character of the line.
         else if self.current_position.character
-            > self.file_lines[self.current_position.line].length + self.numbar_space
+            // > self.file_lines[self.current_position.line].length + self.numbar_space
+            > self.file_text.line(self.current_position.line).len_chars() + self.numbar_space
         {
             // -1 because lines start at 0 and length is always bigger.
             self.current_position.character =
-                self.file_lines[self.current_position.line].length + self.numbar_space - 1;
+                // self.file_lines[self.current_position.line].length + self.numbar_space - 1;
+                self.file_text.line(self.current_position.line).len_chars() + self.numbar_space - 1;
         }
         self.ensure_cursor_visible();
     }
@@ -101,23 +114,27 @@ impl Buffer {
         self.current_position.line = self.current_position.line.saturating_sub(1);
         // Edge case where when going up the line is empty line. Then put cursor
         // after numbar.
-        if self.file_lines[self.current_position.line].length == 0 {
+        // if self.file_lines[self.current_position.line].length == 0 {
+        if self.file_text.line(self.current_position.line).len_chars() == 0 {
             self.current_position.character = self.numbar_space;
         }
         // If current char after going up would be bigger than the new line's
         // length, put it on max character of the line.
         else if self.current_position.character
-            > self.file_lines[self.current_position.line].length + self.numbar_space
+            // > self.file_lines[self.current_position.line].length + self.numbar_space
+            > self.file_text.line(self.current_position.line).len_chars() + self.numbar_space
         {
             // -1 because lines start at 0 and length is always bigger.
             self.current_position.character =
-                self.file_lines[self.current_position.line].length + self.numbar_space - 1;
+                // self.file_lines[self.current_position.line].length + self.numbar_space - 1;
+                self.file_text.line(self.current_position.line).len_chars() + self.numbar_space - 1;
         }
         self.ensure_cursor_visible();
     }
 
     pub fn move_cursor_right(&mut self) {
-        let line_len = self.file_lines[self.current_position.line].length;
+        // let line_len = self.file_lines[self.current_position.line].length;
+        let line_len = self.file_text.line(self.current_position.line).len_chars();
         let max_cursor_pos = line_len + self.numbar_space;
         if self.current_position.character < max_cursor_pos {
             self.current_position.character = self.current_position.character.saturating_add(1);
@@ -126,13 +143,14 @@ impl Buffer {
     }
 
     pub fn insert_line_below(&mut self) {
-        self.file_lines.insert(
-            self.current_position.line + 1,
-            FileLine {
-                content: String::from(""),
-                length: 0,
-            },
-        );
+        // self.file_lines.insert(
+        //     self.current_position.line + 1,
+        //     FileLine {
+        //         content: String::from(""),
+        //         length: 0,
+        //     },
+        // );
+        self.file_text.insert(self.current_position.line + 1, "");
         self.update_numbar_space();
         self.current_position.line = self.current_position.line.saturating_add(1);
         self.current_position.character = self.numbar_space;
@@ -173,7 +191,8 @@ impl Buffer {
         }
 
         // Try next lines
-        for next_line_idx in (line_idx + 1)..self.file_lines.len() {
+        // for next_line_idx in (line_idx + 1)..self.file_lines.len() {
+        for next_line_idx in (line_idx + 1)..self.file_text.len_lines() {
             if let Some(chars) = self.get_line_chars(next_line_idx) {
                 if chars.is_empty() {
                     return Some(BufferPosition {
@@ -308,7 +327,8 @@ impl Buffer {
         }
 
         // Try next lines
-        for next_line_idx in (line_idx + 1)..self.file_lines.len() {
+        // for next_line_idx in (line_idx + 1)..self.file_lines.len() {
+        for next_line_idx in (line_idx + 1)..self.file_text.len_lines() {
             if let Some(chars) = self.get_line_chars(next_line_idx) {
                 if chars.is_empty() {
                     continue;
@@ -328,9 +348,10 @@ impl Buffer {
     }
 
     fn get_line_chars(&self, line_idx: usize) -> Option<Vec<char>> {
-        self.file_lines
-            .get(line_idx)
-            .map(|line| line.content.chars().collect())
+        // self.file_lines
+        //     .get(line_idx)
+        //     .map(|line| line.content.chars().collect())
+        Some(self.file_text.line(line_idx).chars().collect())
     }
 
     fn skip_whitespace_forward(&self, chars: &[char], mut pos: usize) -> usize {

--- a/oxid/src/buffer/movement.rs
+++ b/oxid/src/buffer/movement.rs
@@ -47,24 +47,19 @@ impl Buffer {
     }
 
     pub fn scroll_down(&mut self, lines: usize) {
-        // let max_scroll = (self.file_lines.len()).saturating_sub(self.viewport_height);
         let max_scroll = (self.file_text.len_lines()).saturating_sub(self.viewport_height);
         self.vertical_scroll = std::cmp::min(self.vertical_scroll + lines, max_scroll);
         self.current_position.line = {
-            // if self.current_position.line.saturating_add(lines) > self.file_lines.len() {
-            if self.current_position.line.saturating_add(lines) > self.file_text.len_lines() {
-                // self.file_lines.len() - 1 // Respect the status line
+            if self.current_position.line.saturating_add(lines) > self.file_text.len_lines() - 1 {
                 self.file_text.len_lines() - 1 // Respect the status line
             } else {
                 self.current_position.line.saturating_add(lines)
             }
         };
-        // if self.file_lines[self.current_position.line].length
         if self.file_text.line(self.current_position.line).len_chars()
             < self.current_position.character - self.numbar_space
         {
             self.current_position.character =
-                // self.file_lines[self.current_position.line].length + self.numbar_space;
                 self.file_text.line(self.current_position.line).len_chars() + self.numbar_space;
         }
     }

--- a/oxid/src/buffer/movement.rs
+++ b/oxid/src/buffer/movement.rs
@@ -1,5 +1,5 @@
 use super::core::Buffer;
-use super::types::{BufferPosition, CharType, FileLine};
+use super::types::{BufferPosition, CharType};
 
 impl Buffer {
     pub fn move_to_end_of_word(&mut self) {
@@ -30,7 +30,7 @@ impl Buffer {
     pub fn move_cursor_end_line(&mut self) {
         self.current_position.character =
             // self.file_text[self.current_position.line].length + self.numbar_space;
-            self.file_text.line(self.current_position.line).len_chars() + self.numbar_space;
+            (self.file_text.line(self.current_position.line).len_chars() - 1) + self.numbar_space;
     }
 
     pub fn scroll_up(&mut self, lines: usize) {
@@ -133,8 +133,7 @@ impl Buffer {
     }
 
     pub fn move_cursor_right(&mut self) {
-        // let line_len = self.file_lines[self.current_position.line].length;
-        let line_len = self.file_text.line(self.current_position.line).len_chars();
+        let line_len = self.file_text.line(self.current_position.line).len_chars() - 1;
         let max_cursor_pos = line_len + self.numbar_space;
         if self.current_position.character < max_cursor_pos {
             self.current_position.character = self.current_position.character.saturating_add(1);

--- a/oxid/src/buffer/movement.rs
+++ b/oxid/src/buffer/movement.rs
@@ -143,15 +143,13 @@ impl Buffer {
     }
 
     pub fn insert_line_below(&mut self) {
-        // self.file_lines.insert(
-        //     self.current_position.line + 1,
-        //     FileLine {
-        //         content: String::from(""),
-        //         length: 0,
-        //     },
-        // );
-        self.file_text.insert(self.current_position.line + 1, "");
+        let curr_line = self.current_position.line;
+        let curr_idx = self.file_text.line_to_char(curr_line + 1);
+
+        self.file_text.insert(curr_idx, "\n");
+
         self.update_numbar_space();
+
         self.current_position.line = self.current_position.line.saturating_add(1);
         self.current_position.character = self.numbar_space;
         self.ensure_cursor_visible();

--- a/oxid/src/buffer/movement.rs
+++ b/oxid/src/buffer/movement.rs
@@ -126,8 +126,10 @@ impl Buffer {
     }
 
     pub fn move_cursor_right(&mut self) {
-        let line_len = self.file_text.line(self.current_position.line).len_chars() - 1;
-        let max_cursor_pos = line_len + self.numbar_space;
+        let line_len = self.file_text.line(self.current_position.line).len_chars();
+        // For some reason the -1 must be on this line and not after len_chars() otherwise it
+        // crashes if cursor is on last line, it's empty and tries to go to the right.
+        let max_cursor_pos = line_len + self.numbar_space - 1;
         if self.current_position.character < max_cursor_pos {
             self.current_position.character = self.current_position.character.saturating_add(1);
         }

--- a/oxid/src/buffer/rendering.rs
+++ b/oxid/src/buffer/rendering.rs
@@ -32,22 +32,12 @@ impl Buffer {
 
     pub fn get_visible_lines(&self) -> Vec<ropey::RopeSlice> {
         let start = self.vertical_scroll;
-        // let end = std::cmp::min(start + self.viewport_height, self.file_lines.len());
         let end = std::cmp::min(start + self.viewport_height, self.file_text.len_lines());
 
-        // self.file_lines[start..end].iter().collect()
         (start..end).map(|i| self.file_text.line(i)).collect()
     }
 
     pub fn get_visible_line_content(&self, line: ropey::RopeSlice) -> String {
-        // let start_col = self.horizontal_scroll;
-        // if start_col >= line.content.len() {
-        //     return String::new();
-        // }
-        //
-        // let end_col = std::cmp::min(start_col + self.viewport_width, line.content.len());
-        //
-        // line.content[start_col..end_col].to_string()
         let start_col = self.horizontal_scroll;
         let line_len = line.len_chars();
 

--- a/oxid/src/buffer/rendering.rs
+++ b/oxid/src/buffer/rendering.rs
@@ -1,7 +1,5 @@
-use ropey::RopeSlice;
-
 use super::core::Buffer;
-use super::types::{BufferPosition, FileLine};
+use super::types::BufferPosition;
 
 impl Buffer {
     pub(super) fn ensure_cursor_visible(&mut self) {
@@ -54,7 +52,7 @@ impl Buffer {
         let line_len = line.len_chars();
 
         if start_col >= line_len {
-            return String::new()
+            return String::new();
         }
 
         let end_col = std::cmp::min(start_col + self.viewport_width, line_len);

--- a/oxid/src/buffer/rendering.rs
+++ b/oxid/src/buffer/rendering.rs
@@ -1,3 +1,5 @@
+use ropey::RopeSlice;
+
 use super::core::Buffer;
 use super::types::{BufferPosition, FileLine};
 
@@ -30,22 +32,35 @@ impl Buffer {
         }
     }
 
-    pub fn get_visible_lines(&self) -> Vec<&FileLine> {
+    pub fn get_visible_lines(&self) -> Vec<ropey::RopeSlice> {
         let start = self.vertical_scroll;
-        let end = std::cmp::min(start + self.viewport_height, self.file_lines.len());
+        // let end = std::cmp::min(start + self.viewport_height, self.file_lines.len());
+        let end = std::cmp::min(start + self.viewport_height, self.file_text.len_lines());
 
-        self.file_lines[start..end].iter().collect()
+        // self.file_lines[start..end].iter().collect()
+        (start..end).map(|i| self.file_text.line(i)).collect()
     }
 
-    pub fn get_visible_line_content(&self, line: &FileLine) -> String {
+    pub fn get_visible_line_content(&self, line: ropey::RopeSlice) -> String {
+        // let start_col = self.horizontal_scroll;
+        // if start_col >= line.content.len() {
+        //     return String::new();
+        // }
+        //
+        // let end_col = std::cmp::min(start_col + self.viewport_width, line.content.len());
+        //
+        // line.content[start_col..end_col].to_string()
         let start_col = self.horizontal_scroll;
-        if start_col >= line.content.len() {
-            return String::new();
+        let line_len = line.len_chars();
+
+        if start_col >= line_len {
+            return String::new()
         }
 
-        let end_col = std::cmp::min(start_col + self.viewport_width, line.content.len());
+        let end_col = std::cmp::min(start_col + self.viewport_width, line_len);
 
-        line.content[start_col..end_col].to_string()
+        // TODO: Check this unwrap
+        line.get_slice(start_col..end_col).unwrap().to_string()
     }
 
     pub fn get_viewport_cursor_pos(&self) -> BufferPosition {

--- a/oxid/src/buffer/types.rs
+++ b/oxid/src/buffer/types.rs
@@ -23,12 +23,6 @@ pub struct BufferPosition {
     pub character: usize,
 }
 
-#[derive(Clone, Debug)]
-pub struct FileLine {
-    pub content: String,
-    pub length: usize,
-}
-
 #[derive(Debug, Clone)]
 pub struct Selection {
     pub start: BufferPosition,

--- a/oxid/src/buffer/visual.rs
+++ b/oxid/src/buffer/visual.rs
@@ -3,103 +3,96 @@ use super::core::Buffer;
 impl Buffer {
     pub fn update_selected_string(&mut self) {
         if let Some(selection) = &self.selection {
-            // This means we're just selecting some substring of that line.
+            // Single line selection
             if selection.start.line == selection.end.line {
                 let start = selection.start.character - self.numbar_space;
                 let end = selection.end.character - self.numbar_space;
                 // Normalize so that we don't get indexing errors if selection went backwards.
                 let substr = if start >= end {
-                    // &self.file_lines[selection.start.line].content[end..start]
-                    // TODO: Check this unwrap
                     self.file_text
                         .line(selection.start.line)
                         .get_slice(end..start)
                         .unwrap()
                         .to_string()
                 } else {
-                    // &self.file_lines[selection.start.line].content[start..end]
-                    // TODO: Check this unwrap
                     self.file_text
                         .line(selection.start.line)
                         .get_slice(start..end)
                         .unwrap()
                         .to_string()
                 };
-                self.selected_string = Some(String::from(substr));
+                self.selected_string = Some(substr);
             }
-            // This means selection starts in one line and finishes in another next one (goes
-            // down).
+            // Multi-line selection going down
             else if selection.start.line < selection.end.line {
-                // let start_str = &self.file_lines[selection.start.line].content
-                //     [selection.start.character - self.numbar_space..];
+                let mut final_string = String::new();
+
+                // First line: from start character to end of line
                 let start_str = self
                     .file_text
                     .line(selection.start.line)
                     .slice(selection.start.character - self.numbar_space..)
                     .to_string();
+                final_string.push_str(&start_str);
 
-                let mut final_string = String::from(start_str);
+                // Add newline only if we're going to add more content
+                if selection.end.line > selection.start.line {
+                    final_string.push('\n');
+                }
 
-                let num_lines = selection.end.line - selection.start.line;
-                final_string.push('\n');
-
-                // We get each other line completely besides the last line.
-                for i in 0..num_lines - 1 {
-                    // let line = &self.file_lines[selection.start.line + i + 1].content;
-                    // TODO: Check this unwrap
-                    let line = self
-                        .file_text
-                        .line(selection.start.line + i + 1)
-                        .as_str()
-                        .unwrap();
+                // Middle lines: complete lines
+                for line_num in (selection.start.line + 1)..selection.end.line {
+                    let line = self.file_text.line(line_num).as_str().unwrap();
                     final_string.push_str(line);
                     final_string.push('\n');
                 }
-                // Last line is handled by only taking from 0 to selection.end.char.
-                // let last_line = &self.file_lines[selection.end.line].content
-                //     [0..selection.end.character - self.numbar_space];
-                let last_line = self
-                    .file_text
-                    .line(selection.end.line)
-                    .slice(0..selection.end.character - self.numbar_space)
-                    .to_string();
 
-                final_string.push_str(&last_line);
+                // Last line: from beginning to end character
+                if selection.end.line > selection.start.line {
+                    let last_line = self
+                        .file_text
+                        .line(selection.end.line)
+                        .slice(0..selection.end.character - self.numbar_space)
+                        .to_string();
+                    final_string.push_str(&last_line);
+                }
+
                 self.selected_string = Some(final_string);
-            } else {
-                // If we get here it means that the selection starts in one line and ends in
-                // previous lines (it selected backwards). Start > End. We basically do the same,
-                // but starting from end line and last line is start line.
-                // let start_str = &self.file_lines[selection.end.line].content
-                //     [selection.end.character - self.numbar_space..];
+            }
+            // Multi-line selection going up (backwards selection)
+            else {
+                let mut final_string = String::new();
+
+                // First line: from end character to end of line
                 let start_str = self
                     .file_text
                     .line(selection.end.line)
-                    .slice(selection.end.character - self.numbar_space..);
-
-                let mut final_string = String::from(start_str);
-
-                let num_lines = selection.start.line - selection.end.line;
-
-                // We get each other line completely besides the last line.
-                for i in 0..num_lines - 1 {
-                    // let line = &self.file_lines[selection.end.line + i + 1].content;
-                    let line = self
-                        .file_text
-                        .line(selection.end.line + i + 1)
-                        .to_string();
-                    final_string.push_str(&line);
-                }
-                // Last line is handled by only taking from 0 to selection.end.char.
-                // let last_line = &self.file_lines[selection.start.line].content
-                //     [0..selection.start.character - self.numbar_space];
-                let last_line = self
-                    .file_text
-                    .line(selection.start.line)
-                    .slice(0..selection.start.character - self.numbar_space)
+                    .slice(selection.end.character - self.numbar_space..)
                     .to_string();
+                final_string.push_str(&start_str);
 
-                final_string.push_str(&last_line);
+                // Add newline only if we're going to add more content
+                if selection.start.line > selection.end.line {
+                    final_string.push('\n');
+                }
+
+                // Middle lines: complete lines
+                for line_num in (selection.end.line + 1)..selection.start.line {
+                    let line = self.file_text.line(line_num).to_string();
+                    final_string.push_str(&line);
+                    final_string.push('\n');
+                }
+
+                // Last line: from beginning to start character
+                if selection.start.line > selection.end.line {
+                    let last_line = self
+                        .file_text
+                        .line(selection.start.line)
+                        .slice(0..selection.start.character - self.numbar_space)
+                        .to_string();
+                    final_string.push_str(&last_line);
+                }
+
                 self.selected_string = Some(final_string);
             }
         } else {

--- a/oxid/src/buffer/visual.rs
+++ b/oxid/src/buffer/visual.rs
@@ -35,11 +35,6 @@ impl Buffer {
                     .to_string();
                 final_string.push_str(&start_str);
 
-                // Add newline only if we're going to add more content
-                if selection.end.line > selection.start.line {
-                    final_string.push('\n');
-                }
-
                 // Middle lines: complete lines
                 for line_num in (selection.start.line + 1)..selection.end.line {
                     let line = self.file_text.line(line_num).as_str().unwrap();
@@ -70,11 +65,6 @@ impl Buffer {
                     .slice(selection.end.character - self.numbar_space..)
                     .to_string();
                 final_string.push_str(&start_str);
-
-                // Add newline only if we're going to add more content
-                if selection.start.line > selection.end.line {
-                    final_string.push('\n');
-                }
 
                 // Middle lines: complete lines
                 for line_num in (selection.end.line + 1)..selection.start.line {

--- a/oxid/src/buffer/visual.rs
+++ b/oxid/src/buffer/visual.rs
@@ -9,17 +9,34 @@ impl Buffer {
                 let end = selection.end.character - self.numbar_space;
                 // Normalize so that we don't get indexing errors if selection went backwards.
                 let substr = if start >= end {
-                    &self.file_lines[selection.start.line].content[end..start]
+                    // &self.file_lines[selection.start.line].content[end..start]
+                    // TODO: Check this unwrap
+                    self.file_text
+                        .line(selection.start.line)
+                        .get_slice(end..start)
+                        .unwrap()
+                        .to_string()
                 } else {
-                    &self.file_lines[selection.start.line].content[start..end]
+                    // &self.file_lines[selection.start.line].content[start..end]
+                    // TODO: Check this unwrap
+                    self.file_text
+                        .line(selection.start.line)
+                        .get_slice(start..end)
+                        .unwrap()
+                        .to_string()
                 };
                 self.selected_string = Some(String::from(substr));
             }
             // This means selection starts in one line and finishes in another next one (goes
             // down).
             else if selection.start.line < selection.end.line {
-                let start_str = &self.file_lines[selection.start.line].content
-                    [selection.start.character - self.numbar_space..];
+                // let start_str = &self.file_lines[selection.start.line].content
+                //     [selection.start.character - self.numbar_space..];
+                let start_str = self
+                    .file_text
+                    .line(selection.start.line)
+                    .slice(selection.start.character - self.numbar_space..)
+                    .to_string();
 
                 let mut final_string = String::from(start_str);
 
@@ -28,22 +45,37 @@ impl Buffer {
 
                 // We get each other line completely besides the last line.
                 for i in 0..num_lines - 1 {
-                    let line = &self.file_lines[selection.start.line + i + 1].content;
+                    // let line = &self.file_lines[selection.start.line + i + 1].content;
+                    // TODO: Check this unwrap
+                    let line = self
+                        .file_text
+                        .line(selection.start.line + i + 1)
+                        .as_str()
+                        .unwrap();
                     final_string.push_str(line);
                     final_string.push('\n');
                 }
                 // Last line is handled by only taking from 0 to selection.end.char.
-                let last_line = &self.file_lines[selection.end.line].content
-                    [0..selection.end.character - self.numbar_space];
+                // let last_line = &self.file_lines[selection.end.line].content
+                //     [0..selection.end.character - self.numbar_space];
+                let last_line = self
+                    .file_text
+                    .line(selection.end.line)
+                    .slice(0..selection.end.character - self.numbar_space)
+                    .to_string();
 
-                final_string.push_str(last_line);
+                final_string.push_str(&last_line);
                 self.selected_string = Some(final_string);
             } else {
                 // If we get here it means that the selection starts in one line and ends in
                 // previous lines (it selected backwards). Start > End. We basically do the same,
                 // but starting from end line and last line is start line.
-                let start_str = &self.file_lines[selection.end.line].content
-                    [selection.end.character - self.numbar_space..];
+                // let start_str = &self.file_lines[selection.end.line].content
+                //     [selection.end.character - self.numbar_space..];
+                let start_str = self
+                    .file_text
+                    .line(selection.end.line)
+                    .slice(selection.end.character - self.numbar_space..);
 
                 let mut final_string = String::from(start_str);
 
@@ -51,14 +83,23 @@ impl Buffer {
 
                 // We get each other line completely besides the last line.
                 for i in 0..num_lines - 1 {
-                    let line = &self.file_lines[selection.end.line + i + 1].content;
-                    final_string.push_str(line);
+                    // let line = &self.file_lines[selection.end.line + i + 1].content;
+                    let line = self
+                        .file_text
+                        .line(selection.end.line + i + 1)
+                        .to_string();
+                    final_string.push_str(&line);
                 }
                 // Last line is handled by only taking from 0 to selection.end.char.
-                let last_line = &self.file_lines[selection.start.line].content
-                    [0..selection.start.character - self.numbar_space];
+                // let last_line = &self.file_lines[selection.start.line].content
+                //     [0..selection.start.character - self.numbar_space];
+                let last_line = self
+                    .file_text
+                    .line(selection.start.line)
+                    .slice(0..selection.start.character - self.numbar_space)
+                    .to_string();
 
-                final_string.push_str(last_line);
+                final_string.push_str(&last_line);
                 self.selected_string = Some(final_string);
             }
         } else {

--- a/oxid/src/main.rs
+++ b/oxid/src/main.rs
@@ -1,5 +1,7 @@
 use anyhow::Result;
-use std::fs::read_to_string;
+use ropey::Rope;
+use std::fs::File;
+use std::io::BufReader;
 use std::sync::mpsc::channel;
 
 use oxid::app::App;
@@ -8,16 +10,21 @@ use oxid::events::{EventKind, handle_events};
 
 fn main() -> Result<()> {
     let mut terminal = ratatui::init();
+
     let file_path = oxid::cli::get_file_name_arg()?;
-    let file_text = read_to_string(file_path.clone())?;
+    let file_text = Rope::from_reader(BufReader::new(File::open(&file_path)?))?;
+
     let tsize_x = terminal.size()?.width as usize;
     let tsize_y = terminal.size()?.height as usize;
+
     let mut buffers: Vec<Buffer> = Vec::new();
     buffers.push(Buffer::new(Some(file_path), file_text, tsize_x, tsize_y));
-    let (event_sender, event_receiver) = channel::<EventKind>();
+
     let mut app = App::new(buffers);
+    let (event_sender, event_receiver) = channel::<EventKind>();
     std::thread::spawn(move || handle_events(event_sender));
     let result = app.run(event_receiver, &mut terminal);
+
     ratatui::restore();
     result
 }

--- a/oxid/src/ui/editor_view.rs
+++ b/oxid/src/ui/editor_view.rs
@@ -40,20 +40,13 @@ pub fn ui(frame: &mut Frame, app: &App) {
         .constraints([Constraint::Min(1), Constraint::Length(1)])
         .split(editor_area);
 
-    // // Render only the visible lines
-    // let file_string: Vec<String> = visible_lines
-    //     .iter()
-    //     .map(|line| app.buffers[0].get_visible_line_content(line))
-    //     .collect();
-    // let file_text = Paragraph::new(file_string.join("\n"));
-
     let selection = &app.buffers[0].selection;
     let mut styled_lines: Vec<Line> = Vec::new();
     let start_line = app.buffers[0].vertical_scroll;
     let numbar_space = app.buffers[0].numbar_space;
 
     for (i, visible_line) in visible_lines.iter().enumerate() {
-        let line_content = app.buffers[0].get_visible_line_content(visible_line);
+        let line_content = app.buffers[0].get_visible_line_content(visible_line.to_owned());
         let mut spans: Vec<Span> = Vec::new();
 
         for (char_idx, ch) in line_content.chars().enumerate() {


### PR DESCRIPTION
This PR migrates all the editor's editing system from raw string handling to ropey's Rope type.

The method we were using before was limited to representable ASCII characters, and inserting characters like "ж" or "が" would crash the editor. It also closes the following issues and bugs that arose when implementing this migration.

- Closes #33 
- Closes #34 
- Closes #35 
- Closes #36 