### PR TITLE
feat: command mode implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ As of now, the editor will either open an existing file or create a new one. It 
 ### 📁 **File Management**
 - [ ] **File Operations**
   - [ ] Save as
-  - [ ] Multi-file editing
+  - [x] Multi-file editing
 
 ### 🎨 **User Interface Enhancements**
 - [ ] **Syntax Highlighting**

--- a/README.md
+++ b/README.md
@@ -116,7 +116,10 @@ As of now, the editor will either open an existing file or create a new one. It 
 ### **Command Mode**
 - [ ] **File Management**
     - [ ] Save (:w)
+    - [x] Save All (:wa)
     - [ ] Quit (:q)
+    - [x] Quit All (:qa)
+    - [x] Save and Quit All (:wqa)
     - [ ] Open new buffer (:e <file>)
     - [ ] Go to next buffer (:bn)
     - [ ] Go to prev buffer (:bp)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A simple, vim-inspired terminal text editor built with Rust. This is a personal 
 - **Normal Mode**: Navigate and manipulate text efficiently
 - **Insert Mode**: Type and edit text naturally
 - **Visual Mode**: Select and apply motions to your text
+- **Command Mode**: Apply the main vim commands to your buffers.
 
 ### ⌨️ **Vim-Inspired Navigation**
 - `h`, `j`, `k`, `l` - Move cursor left, down, up, right
@@ -69,6 +70,7 @@ As of now, the editor will either open an existing file or create a new one. It 
 | `Ctrl+s` | Save current file |
 | `Shift+i` | Insert at start of line |
 | `Shift+a` | Append at end of line |
+| `:` | Enter command mode |
 
 ### Insert Mode
 | Key | Action |
@@ -93,6 +95,19 @@ As of now, the editor will either open an existing file or create a new one. It 
 | `0` | Move selection to the start of the line |
 | `$` | Move selection to the end of the line |
 | `y` | Yank current selection to default register |
+
+### Command Mode
+| Command | Action |
+|-----|--------|
+| `:w` | Save current buffer file |
+| `:wa` | Save all buffer files |
+| `:q` | Quit current buffer |
+| `:qa` | Quit all buffers|
+| `:wqa` | Save and quit all buffers |
+| `:e <file_path>` | Open or create a new file |
+| `:bn` | Move to next buffer |
+| `:bp` | Move to previous buffer |
+| `:<line_number>` | Move to specified line on current buffer |
 
 ## 📋 Planned Features
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ As of now, the editor will either open an existing file or create a new one. It 
     - [x] Go to next buffer (:bn)
     - [x] Go to prev buffer (:bp)
 - [ ] **Navigation**
-  - [ ] Go to line number (`:line`)
+  - [x] Go to line number (`:line`)
   - [ ] Search
 
 ### 🧩 **Language Server Protocol**

--- a/README.md
+++ b/README.md
@@ -114,15 +114,15 @@ As of now, the editor will either open an existing file or create a new one. It 
   - [ ] Color scheme
 
 ### **Command Mode**
-- [ ] **File Management**
-    - [ ] Save (:w)
+- [x] **File Management**
+    - [x] Save (:w)
     - [x] Save All (:wa)
-    - [ ] Quit (:q)
+    - [x] Quit (:q)
     - [x] Quit All (:qa)
     - [x] Save and Quit All (:wqa)
-    - [ ] Open new buffer (:e <file>)
-    - [ ] Go to next buffer (:bn)
-    - [ ] Go to prev buffer (:bp)
+    - [x] Open new buffer (:e <file>)
+    - [x] Go to next buffer (:bn)
+    - [x] Go to prev buffer (:bp)
 - [ ] **Navigation**
   - [ ] Go to line number (`:line`)
   - [ ] Search

--- a/oxid/src/app.rs
+++ b/oxid/src/app.rs
@@ -294,6 +294,11 @@ impl App {
                         if self.mode == Mode::Insert {
                             self.buffers[0].remove_char();
                         }
+                        if self.mode == Mode::Command {
+                            if let Some(command) = &mut self.command {
+                                command.pop();
+                            }
+                        }
                     }
                     EventKind::EnterKey => {
                         if self.mode == Mode::Insert {

--- a/oxid/src/app.rs
+++ b/oxid/src/app.rs
@@ -31,6 +31,7 @@ pub struct App {
     pub mode: Mode,
     pub quitting: bool,
     pub buffers: Vec<Buffer>,
+    pub current_buf_index: usize,
     pub registers: HashMap<String, String>,
     pub command: Option<String>,
     pub debug_mode: bool,
@@ -42,6 +43,7 @@ impl App {
             mode: Mode::Normal,
             quitting: false,
             buffers,
+            current_buf_index: 0,
             registers: HashMap::from([(String::from("default"), String::new())]),
             command: None,
             debug_mode: false,
@@ -60,16 +62,20 @@ impl App {
         if self.mode == Mode::Normal {
             // First time on visual, so start saving selection.
             self.mode = Mode::Visual;
-            self.buffers[0].selection = Some(Selection {
-                start: self.buffers[0].current_position.clone(),
-                end: self.buffers[0].current_position.clone(),
+            self.buffers[self.current_buf_index].selection = Some(Selection {
+                start: self.buffers[self.current_buf_index]
+                    .current_position
+                    .clone(),
+                end: self.buffers[self.current_buf_index]
+                    .current_position
+                    .clone(),
             });
-            self.buffers[0].update_selected_string();
+            self.buffers[self.current_buf_index].update_selected_string();
         } else {
             // If on whatever mode but normal, stop selecting and reset.
             self.mode = Mode::Normal;
-            self.buffers[0].selection = None;
-            self.buffers[0].update_selected_string();
+            self.buffers[self.current_buf_index].selection = None;
+            self.buffers[self.current_buf_index].update_selected_string();
         }
     }
     pub fn command_mode(&mut self) {
@@ -80,8 +86,8 @@ impl App {
             // If we don't come from normal mode, just reset everything
             // at least for now.
             self.mode = Mode::Command;
-            self.buffers[0].selection = None;
-            self.buffers[0].update_selected_string();
+            self.buffers[self.current_buf_index].selection = None;
+            self.buffers[self.current_buf_index].update_selected_string();
             self.command = None;
         }
     }
@@ -91,7 +97,7 @@ impl App {
             match Command::parse(cmd_str) {
                 Ok(cmd_type) => {
                     match cmd_type {
-                        Command::SaveFile(file_name) => {
+                        Command::SaveCurrentFile(file_name) => {
                             self.buffers.iter().for_each(|buf| {
                                 if let Some(file_path) = &buf.file_path {
                                     if *file_path == file_name {
@@ -126,7 +132,9 @@ impl App {
                         }
                         // TODO: Implement the rest of these commands.
                         Command::OpenFile(_) => todo!(":e command is not implemented yet!"),
-                        Command::QuitFile(_) => todo!(":q <file_name> is not implemented yet!"),
+                        Command::QuitCurrentFile(_) => {
+                            todo!(":q <file_name> is not implemented yet!")
+                        }
                         Command::NextBuffer => todo!(":bn is not implemented yet!"),
                         Command::PreviousBuffer => todo!(":bp is not implemented yet!"),
                     }
@@ -153,17 +161,17 @@ impl App {
             if let Ok(event) = event_receiver.recv() {
                 match event {
                     EventKind::SaveFile => {
-                        self.buffers[0].save_file()?;
+                        self.buffers[self.current_buf_index].save_file()?;
                         self.normal_mode();
                     }
                     EventKind::Quit => self.quitting = true,
                     EventKind::NormalMode => {
                         self.normal_mode();
-                        self.buffers[0].selection = None;
-                        self.buffers[0].selected_string = None;
+                        self.buffers[self.current_buf_index].selection = None;
+                        self.buffers[self.current_buf_index].selected_string = None;
                     }
-                    EventKind::ScrollUp => self.buffers[0].scroll_up(5),
-                    EventKind::ScrollDown => self.buffers[0].scroll_down(5),
+                    EventKind::ScrollUp => self.buffers[self.current_buf_index].scroll_up(5),
+                    EventKind::ScrollDown => self.buffers[self.current_buf_index].scroll_down(5),
                     EventKind::KeyPressed(ch) => {
                         if self.mode == Mode::Command {
                             if let Some(cmd_str) = &mut self.command {
@@ -178,86 +186,121 @@ impl App {
                                 ':' => self.command_mode(),
                                 'v' => self.visual_mode(),
                                 'h' => {
-                                    self.buffers[0].move_cursor_left();
+                                    self.buffers[self.current_buf_index].move_cursor_left();
                                     if vis {
-                                        if let Some(selection) = &self.buffers[0].selection {
+                                        if let Some(selection) =
+                                            &self.buffers[self.current_buf_index].selection
+                                        {
                                             let start = selection.start.clone();
-                                            let end = self.buffers[0].current_position.clone();
-                                            self.buffers[0].selection =
+                                            let end = self.buffers[self.current_buf_index]
+                                                .current_position
+                                                .clone();
+                                            self.buffers[self.current_buf_index].selection =
                                                 Some(Selection { start, end });
-                                            self.buffers[0].update_selected_string();
+                                            self.buffers[self.current_buf_index]
+                                                .update_selected_string();
                                         }
                                     }
                                 }
                                 'j' => {
-                                    self.buffers[0].move_cursor_down();
+                                    self.buffers[self.current_buf_index].move_cursor_down();
                                     if vis {
-                                        if let Some(selection) = &self.buffers[0].selection {
+                                        if let Some(selection) =
+                                            &self.buffers[self.current_buf_index].selection
+                                        {
                                             let start = selection.start.clone();
-                                            let end = self.buffers[0].current_position.clone();
-                                            self.buffers[0].selection =
+                                            let end = self.buffers[self.current_buf_index]
+                                                .current_position
+                                                .clone();
+                                            self.buffers[self.current_buf_index].selection =
                                                 Some(Selection { start, end });
-                                            self.buffers[0].update_selected_string();
+                                            self.buffers[self.current_buf_index]
+                                                .update_selected_string();
                                         }
                                     }
                                 }
                                 'k' => {
-                                    self.buffers[0].move_cursor_up();
+                                    self.buffers[self.current_buf_index].move_cursor_up();
                                     if vis {
-                                        if let Some(selection) = &self.buffers[0].selection {
+                                        if let Some(selection) =
+                                            &self.buffers[self.current_buf_index].selection
+                                        {
                                             let start = selection.start.clone();
-                                            let end = self.buffers[0].current_position.clone();
-                                            self.buffers[0].selection =
+                                            let end = self.buffers[self.current_buf_index]
+                                                .current_position
+                                                .clone();
+                                            self.buffers[self.current_buf_index].selection =
                                                 Some(Selection { start, end });
-                                            self.buffers[0].update_selected_string();
+                                            self.buffers[self.current_buf_index]
+                                                .update_selected_string();
                                         }
                                     }
                                 }
                                 'l' => {
-                                    self.buffers[0].move_cursor_right();
+                                    self.buffers[self.current_buf_index].move_cursor_right();
                                     if vis {
-                                        if let Some(selection) = &self.buffers[0].selection {
+                                        if let Some(selection) =
+                                            &self.buffers[self.current_buf_index].selection
+                                        {
                                             let start = selection.start.clone();
-                                            let end = self.buffers[0].current_position.clone();
-                                            self.buffers[0].selection =
+                                            let end = self.buffers[self.current_buf_index]
+                                                .current_position
+                                                .clone();
+                                            self.buffers[self.current_buf_index].selection =
                                                 Some(Selection { start, end });
-                                            self.buffers[0].update_selected_string();
+                                            self.buffers[self.current_buf_index]
+                                                .update_selected_string();
                                         }
                                     }
                                 }
                                 'w' => {
-                                    self.buffers[0].move_to_next_word();
+                                    self.buffers[self.current_buf_index].move_to_next_word();
                                     if vis {
-                                        if let Some(selection) = &self.buffers[0].selection {
+                                        if let Some(selection) =
+                                            &self.buffers[self.current_buf_index].selection
+                                        {
                                             let start = selection.start.clone();
-                                            let end = self.buffers[0].current_position.clone();
-                                            self.buffers[0].selection =
+                                            let end = self.buffers[self.current_buf_index]
+                                                .current_position
+                                                .clone();
+                                            self.buffers[self.current_buf_index].selection =
                                                 Some(Selection { start, end });
-                                            self.buffers[0].update_selected_string();
+                                            self.buffers[self.current_buf_index]
+                                                .update_selected_string();
                                         }
                                     }
                                 }
                                 'b' => {
-                                    self.buffers[0].move_to_previous_word();
+                                    self.buffers[self.current_buf_index].move_to_previous_word();
                                     if vis {
-                                        if let Some(selection) = &self.buffers[0].selection {
+                                        if let Some(selection) =
+                                            &self.buffers[self.current_buf_index].selection
+                                        {
                                             let start = selection.start.clone();
-                                            let end = self.buffers[0].current_position.clone();
-                                            self.buffers[0].selection =
+                                            let end = self.buffers[self.current_buf_index]
+                                                .current_position
+                                                .clone();
+                                            self.buffers[self.current_buf_index].selection =
                                                 Some(Selection { start, end });
-                                            self.buffers[0].update_selected_string();
+                                            self.buffers[self.current_buf_index]
+                                                .update_selected_string();
                                         }
                                     }
                                 }
                                 'e' => {
-                                    self.buffers[0].move_to_end_of_word();
+                                    self.buffers[self.current_buf_index].move_to_end_of_word();
                                     if vis {
-                                        if let Some(selection) = &self.buffers[0].selection {
+                                        if let Some(selection) =
+                                            &self.buffers[self.current_buf_index].selection
+                                        {
                                             let start = selection.start.clone();
-                                            let end = self.buffers[0].current_position.clone();
-                                            self.buffers[0].selection =
+                                            let end = self.buffers[self.current_buf_index]
+                                                .current_position
+                                                .clone();
+                                            self.buffers[self.current_buf_index].selection =
                                                 Some(Selection { start, end });
-                                            self.buffers[0].update_selected_string();
+                                            self.buffers[self.current_buf_index]
+                                                .update_selected_string();
                                         }
                                     }
                                 }
@@ -268,43 +311,55 @@ impl App {
                                 }
                                 'o' => {
                                     if !vis {
-                                        self.buffers[0].insert_line_below();
+                                        self.buffers[self.current_buf_index].insert_line_below();
                                         self.insert_mode();
                                     }
                                 }
                                 '0' => {
-                                    self.buffers[0].move_cursor_start_line();
+                                    self.buffers[self.current_buf_index].move_cursor_start_line();
                                     if vis {
-                                        if let Some(selection) = &self.buffers[0].selection {
+                                        if let Some(selection) =
+                                            &self.buffers[self.current_buf_index].selection
+                                        {
                                             let start = selection.start.clone();
-                                            let end = self.buffers[0].current_position.clone();
-                                            self.buffers[0].selection =
+                                            let end = self.buffers[self.current_buf_index]
+                                                .current_position
+                                                .clone();
+                                            self.buffers[self.current_buf_index].selection =
                                                 Some(Selection { start, end });
-                                            self.buffers[0].update_selected_string();
+                                            self.buffers[self.current_buf_index]
+                                                .update_selected_string();
                                         }
                                     }
                                 }
                                 '$' => {
-                                    self.buffers[0].move_cursor_end_line();
+                                    self.buffers[self.current_buf_index].move_cursor_end_line();
                                     if vis {
-                                        if let Some(selection) = &self.buffers[0].selection {
+                                        if let Some(selection) =
+                                            &self.buffers[self.current_buf_index].selection
+                                        {
                                             let start = selection.start.clone();
-                                            let end = self.buffers[0].current_position.clone();
-                                            self.buffers[0].selection =
+                                            let end = self.buffers[self.current_buf_index]
+                                                .current_position
+                                                .clone();
+                                            self.buffers[self.current_buf_index].selection =
                                                 Some(Selection { start, end });
-                                            self.buffers[0].update_selected_string();
+                                            self.buffers[self.current_buf_index]
+                                                .update_selected_string();
                                         }
                                     }
                                 }
                                 'y' => {
                                     if vis {
-                                        if let Some(selection) = &self.buffers[0].selected_string {
+                                        if let Some(selection) =
+                                            &self.buffers[self.current_buf_index].selected_string
+                                        {
                                             self.registers.insert(
                                                 String::from("default"),
                                                 selection.to_string(),
                                             );
                                             self.normal_mode();
-                                            self.buffers[0].selection = None;
+                                            self.buffers[self.current_buf_index].selection = None;
                                         }
                                     }
                                 }
@@ -312,7 +367,8 @@ impl App {
                                     if !vis {
                                         if let Some(paste_string) = self.registers.get("default") {
                                             if !paste_string.is_empty() {
-                                                self.buffers[0].paste(paste_string.to_owned());
+                                                self.buffers[self.current_buf_index]
+                                                    .paste(paste_string.to_owned());
                                             }
                                         }
                                     }
@@ -320,18 +376,18 @@ impl App {
                                 _ => {}
                             }
                         } else if self.mode == Mode::Insert {
-                            self.buffers[0].insert_char(ch);
+                            self.buffers[self.current_buf_index].insert_char(ch);
                         }
                     }
                     EventKind::ShiftedKey(ch) => {
                         if self.mode == Mode::Normal {
                             match ch {
                                 'I' => {
-                                    self.buffers[0].move_cursor_start_line();
+                                    self.buffers[self.current_buf_index].move_cursor_start_line();
                                     self.insert_mode();
                                 }
                                 'A' => {
-                                    self.buffers[0].move_cursor_end_line();
+                                    self.buffers[self.current_buf_index].move_cursor_end_line();
                                     self.insert_mode();
                                 }
                                 _ => {}
@@ -339,7 +395,7 @@ impl App {
                         } else if self.mode == Mode::Insert
                             && (ch.is_alphanumeric() || ch.is_ascii_punctuation())
                         {
-                            self.buffers[0].insert_char(ch);
+                            self.buffers[self.current_buf_index].insert_char(ch);
                         } else if self.mode == Mode::Command {
                             if let Some(cmd_str) = &mut self.command {
                                 cmd_str.push(ch);
@@ -350,7 +406,7 @@ impl App {
                     }
                     EventKind::Backspace => {
                         if self.mode == Mode::Insert {
-                            self.buffers[0].remove_char();
+                            self.buffers[self.current_buf_index].remove_char();
                         }
                         if self.mode == Mode::Command {
                             if let Some(command) = &mut self.command {
@@ -360,7 +416,7 @@ impl App {
                     }
                     EventKind::EnterKey => {
                         if self.mode == Mode::Insert {
-                            self.buffers[0].enter_key();
+                            self.buffers[self.current_buf_index].enter_key();
                         } else if self.mode == Mode::Command {
                             self.apply_command();
                         }

--- a/oxid/src/app.rs
+++ b/oxid/src/app.rs
@@ -179,6 +179,22 @@ impl App {
                             self.mode = Mode::Normal;
                             self.command = None;
                         }
+                        Command::GoToLine(line_num) => {
+                            let max_buf_lines =
+                                self.buffers[self.current_buf_index].file_text.len_lines() - 1;
+
+                            if line_num == -1 || line_num > max_buf_lines as isize {
+                                self.buffers[self.current_buf_index].current_position.line =
+                                    max_buf_lines;
+                                self.buffers[self.current_buf_index].ensure_cursor_visible();
+                            } else {
+                                self.buffers[self.current_buf_index].current_position.line =
+                                    line_num as usize;
+                                self.buffers[self.current_buf_index].ensure_cursor_visible();
+                            }
+                            self.mode = Mode::Normal;
+                            self.command = None;
+                        }
                     }
                 }
                 Err(_) => {

--- a/oxid/src/buffer/rendering.rs
+++ b/oxid/src/buffer/rendering.rs
@@ -2,7 +2,7 @@ use super::core::Buffer;
 use super::types::BufferPosition;
 
 impl Buffer {
-    pub(super) fn ensure_cursor_visible(&mut self) {
+    pub fn ensure_cursor_visible(&mut self) {
         let cursor_line = self.current_position.line;
         let viewport_bottom = self.vertical_scroll + self.viewport_height;
 

--- a/oxid/src/command.rs
+++ b/oxid/src/command.rs
@@ -1,16 +1,18 @@
 use std::str::FromStr;
 
 pub enum Command {
-    SaveAll,     // "wa"
-    QuitAll,     // "qa"
+    SaveAll,     // ":wa"
+    QuitAll,     // ":qa"
     SaveQuitAll, // "wqa"
 
-    QuitCurrentFile,  // "q"
-    SaveCurrentFile,  // "w"
-    OpenFile(String), // "e file_name"
+    QuitCurrentFile,  // ":q"
+    SaveCurrentFile,  // ":w"
+    OpenFile(String), // ":e file_name"
 
-    NextBuffer,     // "bn"
-    PreviousBuffer, // "bp"
+    NextBuffer,     // ":bn"
+    PreviousBuffer, // ":bp"
+
+    GoToLine(isize), // ":12"
 }
 
 impl Command {
@@ -30,18 +32,14 @@ impl FromStr for Command {
                     if cmd_parts.next().is_none() {
                         Ok(Self::QuitCurrentFile)
                     } else {
-                        anyhow::bail!(
-                            ":q command does not accept sub arguments"
-                        )
+                        anyhow::bail!(":q command does not accept sub arguments")
                     }
                 }
                 "w" => {
                     if cmd_parts.next().is_none() {
                         Ok(Self::SaveCurrentFile)
                     } else {
-                        anyhow::bail!(
-                            ":w command does not accept sub arguments"
-                        )
+                        anyhow::bail!(":w command does not accept sub arguments")
                     }
                 }
                 "e" => {
@@ -60,6 +58,10 @@ impl FromStr for Command {
 
                 "bn" => Ok(Self::NextBuffer),
                 "bp" => Ok(Self::PreviousBuffer),
+
+                num if num.parse::<usize>().is_ok() => {
+                    Ok(Self::GoToLine(num.parse::<isize>().unwrap_or(-1)))
+                }
 
                 _ => anyhow::bail!("Unknown command: {cmd}"),
             }

--- a/oxid/src/command.rs
+++ b/oxid/src/command.rs
@@ -1,0 +1,70 @@
+use std::str::FromStr;
+
+pub enum Command {
+    SaveAll,     // "wa"
+    QuitAll,     // "qa"
+    SaveQuitAll, // "wqa"
+
+    QuitFile(String), // "q file_name" // TODO: Not provide filename, just pick current buffer.
+    SaveFile(String), // "w file_name" // TODO: Not provide filename, just pick current buffer.
+    OpenFile(String), // "e file_name"
+
+    NextBuffer,     // "bn"
+    PreviousBuffer, // "bp"
+}
+
+impl Command {
+    pub fn parse(input: &str) -> anyhow::Result<Self> {
+        input.parse()
+    }
+}
+
+impl FromStr for Command {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut cmd_parts = s.split_whitespace();
+        if let Some(cmd) = cmd_parts.next() {
+            match cmd {
+                "q" => {
+                    if let Some(file_name) = cmd_parts.next() {
+                        Ok(Self::QuitFile(String::from(file_name)))
+                    } else {
+                        anyhow::bail!(
+                            "For now ':q <file_name>' must be accompanied by a file name."
+                        )
+                    }
+                }
+                "w" => {
+                    if let Some(file_name) = cmd_parts.next() {
+                        Ok(Self::SaveFile(String::from(file_name)))
+                    } else {
+                        anyhow::bail!(
+                            "For now ':w <file_name>' must be accompanied by a file name."
+                        )
+                    }
+                }
+                "e" => {
+                    if let Some(file_name) = cmd_parts.next() {
+                        Ok(Self::SaveFile(String::from(file_name)))
+                    } else {
+                        anyhow::bail!(
+                            "For now ':e <file_name>' must be accompanied by a file name."
+                        )
+                    }
+                }
+
+                "qa" => Ok(Self::QuitAll),
+                "wa" => Ok(Self::SaveAll),
+                "wqa" => Ok(Self::SaveQuitAll),
+
+                "bn" => Ok(Self::NextBuffer),
+                "bp" => Ok(Self::PreviousBuffer),
+
+                _ => anyhow::bail!("Unknown command: {cmd}"),
+            }
+        } else {
+            anyhow::bail!("Empty command is not valid!")
+        }
+    }
+}

--- a/oxid/src/command.rs
+++ b/oxid/src/command.rs
@@ -5,8 +5,8 @@ pub enum Command {
     QuitAll,     // "qa"
     SaveQuitAll, // "wqa"
 
-    QuitCurrentFile(String), // "q file_name" // TODO: Not provide filename, just pick current buffer.
-    SaveCurrentFile(String), // "w file_name" // TODO: Not provide filename, just pick current buffer.
+    QuitCurrentFile,  // "q"
+    SaveCurrentFile,  // "w"
     OpenFile(String), // "e file_name"
 
     NextBuffer,     // "bn"
@@ -27,26 +27,26 @@ impl FromStr for Command {
         if let Some(cmd) = cmd_parts.next() {
             match cmd {
                 "q" => {
-                    if let Some(file_name) = cmd_parts.next() {
-                        Ok(Self::QuitCurrentFile(String::from(file_name)))
+                    if let None = cmd_parts.next() {
+                        Ok(Self::QuitCurrentFile)
                     } else {
                         anyhow::bail!(
-                            "For now ':q <file_name>' must be accompanied by a file name."
+                            ":q command does not accept sub arguments"
                         )
                     }
                 }
                 "w" => {
-                    if let Some(file_name) = cmd_parts.next() {
-                        Ok(Self::SaveCurrentFile(String::from(file_name)))
+                    if let None = cmd_parts.next() {
+                        Ok(Self::SaveCurrentFile)
                     } else {
                         anyhow::bail!(
-                            "For now ':w <file_name>' must be accompanied by a file name."
+                            ":w command does not accept sub arguments"
                         )
                     }
                 }
                 "e" => {
                     if let Some(file_name) = cmd_parts.next() {
-                        Ok(Self::SaveCurrentFile(String::from(file_name)))
+                        Ok(Self::OpenFile(String::from(file_name)))
                     } else {
                         anyhow::bail!(
                             "For now ':e <file_name>' must be accompanied by a file name."

--- a/oxid/src/command.rs
+++ b/oxid/src/command.rs
@@ -27,7 +27,7 @@ impl FromStr for Command {
         if let Some(cmd) = cmd_parts.next() {
             match cmd {
                 "q" => {
-                    if let None = cmd_parts.next() {
+                    if cmd_parts.next().is_none() {
                         Ok(Self::QuitCurrentFile)
                     } else {
                         anyhow::bail!(
@@ -36,7 +36,7 @@ impl FromStr for Command {
                     }
                 }
                 "w" => {
-                    if let None = cmd_parts.next() {
+                    if cmd_parts.next().is_none() {
                         Ok(Self::SaveCurrentFile)
                     } else {
                         anyhow::bail!(

--- a/oxid/src/command.rs
+++ b/oxid/src/command.rs
@@ -5,8 +5,8 @@ pub enum Command {
     QuitAll,     // "qa"
     SaveQuitAll, // "wqa"
 
-    QuitFile(String), // "q file_name" // TODO: Not provide filename, just pick current buffer.
-    SaveFile(String), // "w file_name" // TODO: Not provide filename, just pick current buffer.
+    QuitCurrentFile(String), // "q file_name" // TODO: Not provide filename, just pick current buffer.
+    SaveCurrentFile(String), // "w file_name" // TODO: Not provide filename, just pick current buffer.
     OpenFile(String), // "e file_name"
 
     NextBuffer,     // "bn"
@@ -28,7 +28,7 @@ impl FromStr for Command {
             match cmd {
                 "q" => {
                     if let Some(file_name) = cmd_parts.next() {
-                        Ok(Self::QuitFile(String::from(file_name)))
+                        Ok(Self::QuitCurrentFile(String::from(file_name)))
                     } else {
                         anyhow::bail!(
                             "For now ':q <file_name>' must be accompanied by a file name."
@@ -37,7 +37,7 @@ impl FromStr for Command {
                 }
                 "w" => {
                     if let Some(file_name) = cmd_parts.next() {
-                        Ok(Self::SaveFile(String::from(file_name)))
+                        Ok(Self::SaveCurrentFile(String::from(file_name)))
                     } else {
                         anyhow::bail!(
                             "For now ':w <file_name>' must be accompanied by a file name."
@@ -46,7 +46,7 @@ impl FromStr for Command {
                 }
                 "e" => {
                     if let Some(file_name) = cmd_parts.next() {
-                        Ok(Self::SaveFile(String::from(file_name)))
+                        Ok(Self::SaveCurrentFile(String::from(file_name)))
                     } else {
                         anyhow::bail!(
                             "For now ':e <file_name>' must be accompanied by a file name."

--- a/oxid/src/lib.rs
+++ b/oxid/src/lib.rs
@@ -3,3 +3,4 @@ pub mod buffer;
 pub mod cli;
 pub mod events;
 pub mod ui;
+pub mod command;

--- a/oxid/src/main.rs
+++ b/oxid/src/main.rs
@@ -20,7 +20,7 @@ fn main() -> Result<()> {
     let mut buffers: Vec<Buffer> = Vec::new();
     buffers.push(Buffer::new(Some(file_path), file_text, tsize_x, tsize_y));
 
-    let mut app = App::new(buffers);
+    let mut app = App::new(buffers, tsize_x, tsize_y);
     let (event_sender, event_receiver) = channel::<EventKind>();
     std::thread::spawn(move || handle_events(event_sender));
     let result = app.run(event_receiver, &mut terminal);

--- a/oxid/src/ui.rs
+++ b/oxid/src/ui.rs
@@ -1,3 +1,4 @@
+pub(super) mod command;
 pub(super) mod debug;
 pub mod editor_view;
 

--- a/oxid/src/ui/command.rs
+++ b/oxid/src/ui/command.rs
@@ -1,0 +1,88 @@
+use ratatui::{
+    buffer::Buffer,
+    layout::{Alignment, Rect},
+    style::{Color, Style, Stylize},
+    text::{Line, Text},
+    widgets::{Block, Borders, Clear, Paragraph, Widget, Wrap},
+};
+
+#[derive(Debug, Default)]
+pub(super) struct CommandPopup<'a> {
+    pub title: Line<'a>,
+    pub content: Text<'a>,
+    pub border_style: Style,
+    pub title_style: Style,
+    pub style: Style,
+}
+
+impl Widget for CommandPopup<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        Clear.render(area, buf);
+        let block = Block::new()
+            .bg(Color::Rgb(40, 30, 51))
+            .title(self.title)
+            .title_alignment(Alignment::Center)
+            .title_style(self.title_style)
+            .borders(Borders::ALL)
+            .border_style(self.border_style);
+        Paragraph::new(self.content)
+            .wrap(Wrap { trim: true })
+            .style(self.style)
+            .block(block)
+            .render(area, buf);
+    }
+}
+
+impl<'a> CommandPopup<'a> {
+    pub fn title(self, title: &'a str) -> Self {
+        Self {
+            title: Line::from(title),
+            content: self.content,
+            border_style: self.border_style,
+            title_style: self.title_style,
+            style: self.style,
+        }
+    }
+    pub fn content(self, content: &'a str) -> Self {
+        let mut prefix = String::from(":");
+        prefix.push_str(content);
+
+        Self {
+            title: self.title,
+            content: Text::from(prefix),
+            border_style: self.border_style,
+            title_style: self.title_style,
+            style: self.style,
+        }
+    }
+
+    pub fn style(self, style: Style) -> Self {
+        Self {
+            title: self.title,
+            content: self.content,
+            border_style: self.border_style,
+            title_style: self.title_style,
+            style,
+        }
+    }
+
+    pub fn title_style(self, title_style: Style) -> Self {
+        Self {
+            title: self.title,
+            content: self.content,
+            border_style: self.border_style,
+            style: self.style,
+            title_style,
+        }
+    }
+
+    pub fn border_style(self, border_style: Style) -> Self {
+        Self {
+            title: self.title,
+            content: self.content,
+            style: self.style,
+            title_style: self.title_style,
+            border_style,
+        }
+    }
+}

--- a/oxid/src/ui/editor_view.rs
+++ b/oxid/src/ui/editor_view.rs
@@ -119,22 +119,13 @@ pub fn ui(frame: &mut Frame, app: &App) {
             .constraints([Constraint::Percentage(75), Constraint::Percentage(25)])
             .split(editor_area_chunks[0]);
         frame.render_widget(file_text, editor_subareas[0]);
+        let mode = app.mode.to_string();
+        let command = app.command.clone();
 
-        let mut curr_sel = format!("{:?}", app.buffers[0].selection.clone());
-        let curr_selected_value = format!("{:?}", app.buffers[0].selected_string.clone());
-
-        curr_sel.push('\n');
-        curr_sel.push_str(&curr_selected_value);
-
-        let default_register_contents = app.registers.get("default");
-        curr_sel.push('\n');
-
-        curr_sel.push_str(
-            default_register_contents.unwrap_or(&"Nothing to default register yet.".to_string()),
-        );
+        let dbg_str = format!("MODE: {mode}\n CURRENT COMMAND: {command:#?}");
 
         let popup = DebugPopup::default()
-            .content(&curr_sel)
+            .content(&dbg_str)
             .style(Style::new().yellow())
             .title("Debug selection")
             .title_style(Style::new().white().bold())

--- a/oxid/src/ui/editor_view.rs
+++ b/oxid/src/ui/editor_view.rs
@@ -26,19 +26,19 @@ pub fn ui(frame: &mut Frame, app: &App) {
     let top_area = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([
-            Constraint::Length(app.buffers[0].numbar_space as u16),
+            Constraint::Length(app.buffers[app.current_buf_index].numbar_space as u16),
             Constraint::Fill(1),
         ])
         .split(terminal_area[0]);
 
     // Get visible lines for the current viewport
-    let visible_lines = app.buffers[0].get_visible_lines();
+    let visible_lines = app.buffers[app.current_buf_index].get_visible_lines();
 
     // Render line numbers for only the visible lines
     let numbar_area = top_area[0];
     let nums_of_lines = {
         let mut vec_nums: Vec<String> = Vec::new();
-        let start_line = app.buffers[0].vertical_scroll;
+        let start_line = app.buffers[app.current_buf_index].vertical_scroll;
         for (i, _) in visible_lines.iter().enumerate() {
             vec_nums.push((start_line + i).to_string())
         }
@@ -56,13 +56,14 @@ pub fn ui(frame: &mut Frame, app: &App) {
         ])
         .split(editor_area);
 
-    let selection = &app.buffers[0].selection;
+    let selection = &app.buffers[app.current_buf_index].selection;
     let mut styled_lines: Vec<Line> = Vec::new();
-    let start_line = app.buffers[0].vertical_scroll;
-    let numbar_space = app.buffers[0].numbar_space;
+    let start_line = app.buffers[app.current_buf_index].vertical_scroll;
+    let numbar_space = app.buffers[app.current_buf_index].numbar_space;
 
     for (i, visible_line) in visible_lines.iter().enumerate() {
-        let line_content = app.buffers[0].get_visible_line_content(visible_line.to_owned());
+        let line_content =
+            app.buffers[app.current_buf_index].get_visible_line_content(visible_line.to_owned());
         let mut spans: Vec<Span> = Vec::new();
 
         for (char_idx, ch) in line_content.chars().enumerate() {
@@ -106,7 +107,7 @@ pub fn ui(frame: &mut Frame, app: &App) {
     let file_text = Paragraph::new(styled_lines).style(Color::Rgb(164, 160, 232));
 
     // Get cursor position relative to the viewport
-    let viewport_cursor = app.buffers[0].get_viewport_cursor_pos();
+    let viewport_cursor = app.buffers[app.current_buf_index].get_viewport_cursor_pos();
     frame.set_cursor_position(Position {
         x: viewport_cursor.character as u16,
         y: viewport_cursor.line as u16,
@@ -174,18 +175,18 @@ pub fn ui(frame: &mut Frame, app: &App) {
     let mode = format!(
         "  {} Mode :: {}",
         app.mode,
-        app.buffers[0]
+        app.buffers[app.current_buf_index]
             .file_path
             .clone()
             .unwrap_or("New File".to_string())
     );
     let cursor_pos = format!(
         "{}:{}",
-        app.buffers[0].current_position.line,
-        app.buffers[0]
+        app.buffers[app.current_buf_index].current_position.line,
+        app.buffers[app.current_buf_index]
             .current_position
             .character
-            .saturating_sub(app.buffers[0].numbar_space),
+            .saturating_sub(app.buffers[app.current_buf_index].numbar_space),
     );
     let area_width = editor_area_chunks[1].width as usize;
     let mode_width = mode.chars().count();


### PR DESCRIPTION
This PR provides the functionality of command mode, invoked when inputting ":" on Normal Mode, just like vim.

It also provides the following default commands:
- :w (save buffer)
- :wa (save all buffers)
- :q (quit buffer)
- :qa (quit all buffers)
- :wqa (save and quit all buffers)
- :e file (open or create and open a new file buffer)
- :line_number (go to line number)

This PR also closes the following issues:
- Closes #38 
- Closes #39 
- Closes #40 
- Closes #41 
- Closes #42 
- Closes #43 
- Closes #44 
- Closes #45