### PR TITLE
Fix shift + a motion on last line

### DIFF
--- a/oxid/src/buffer/movement.rs
+++ b/oxid/src/buffer/movement.rs
@@ -28,8 +28,18 @@ impl Buffer {
         self.current_position.character = self.numbar_space;
     }
     pub fn move_cursor_end_line(&mut self) {
-        self.current_position.character =
-            (self.file_text.line(self.current_position.line).len_chars() - 1) + self.numbar_space;
+        // There is a bug that if its on last line we need to add +1 or else it moves
+        // the cursor to the second last char.
+        if self.current_position.line != self.file_text.len_lines() - 1 {
+            self.current_position.character =
+                (self.file_text.line(self.current_position.line).len_chars() - 1)
+                    + self.numbar_space;
+        } else {
+            self.current_position.character =
+                (self.file_text.line(self.current_position.line).len_chars() - 1)
+                    + self.numbar_space
+                    + 1;
+        }
     }
 
     pub fn scroll_up(&mut self, lines: usize) {

--- a/oxid/tests/data/exceptions.py
+++ b/oxid/tests/data/exceptions.py
@@ -1,4 +1,6 @@
-class PipelineDoesNotExists(Exception):
+class PipelineDoesNotExists(Exception):asdfasdfas
     def __init__(self, pipeline_name):
         self.message = f"Pipeline {pipeline_name} does not exists."
         super().__init__(self.message)
+
+patataasdfasdfasdf


### PR DESCRIPTION
This PR addresses the bug in #49 where using the motion of Shift+A on the last line would move the cursor in insert mode to the second last character instead of the last, but work correctly on the rest of the lines.

This PR closes:
- Close #49 