### PR TITLE
Fix: Command prompt render resolution issues

### DIFF
--- a/oxid/src/ui/editor_view.rs
+++ b/oxid/src/ui/editor_view.rs
@@ -132,14 +132,12 @@ pub fn ui(frame: &mut Frame, app: &App) {
         // Render editor content first
         frame.render_widget(file_text, editor_area_chunks[0]);
 
-        // TODO: If the zoom is too much, it doesn't render the command popup correctly.
         // Then render command popup on top
         let editor_subareas = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
-                Constraint::Percentage(6),
-                Constraint::Percentage(6),
-                Constraint::Percentage(6),
+                Constraint::Length(3),
+                Constraint::Length(3),
                 Constraint::Fill(1),
             ])
             .split(editor_area_chunks[0]);


### PR DESCRIPTION
This PR fixes the bug where depending on the resolution of the terminal, if it's too low or too zoomed in, the command prompt will not show correctly. This makes it so that it always appears after the third top line and always uses 3 lines to render.