### PR TITLE
feat: lsp selection through configuration and commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "indexmap"
+version = "2.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92119844f513ffa41556430369ab02c295a3578af21cf945caa3e9e0c2481ac3"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +510,8 @@ dependencies = [
  "oxid-lsp",
  "ratatui",
  "ropey",
+ "serde",
+ "toml",
 ]
 
 [[package]]
@@ -675,18 +687,28 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -703,6 +725,15 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2789234a13a53fc4be1b51ea1bab45a3c338bdb884862a257d10e5a74ae009e6"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -859,6 +890,45 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "toml"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae2a4cf385da23d1d53bc15cdfa5c2109e93d8d362393c801e87da2f72f0e201"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a197c0ec7d131bfc6f7e82c8442ba1595aeab35da7adbf05b6b73cd06a16b6be"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "unicode-ident"
@@ -1075,3 +1145,9 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ members = [
 [workspace.dependencies]
 anyhow = "1.0.98"
 tokio = { version = "1.47.1", features = ["full"]}
+serde = { version = "1.0.219", features = ["derive"] }

--- a/oxid-lsp/Cargo.toml
+++ b/oxid-lsp/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-serde = { version = "1.0.219", features = ["derive"] }
-serde_json = "1.0.143"
 anyhow.workspace = true
 tokio.workspace = true
+serde.workspace = true
+serde_json = "1.0.143"
 bon = "3.7.1"

--- a/oxid-lsp/src/client.rs
+++ b/oxid-lsp/src/client.rs
@@ -126,9 +126,16 @@ pub fn lsp_send_notification(
     Ok(())
 }
 
-pub fn start_lsp() -> anyhow::Result<LspClient> {
-    let mut lsp = Command::new("pyrefly")
-        .arg("lsp")
+pub fn start_lsp(lsp_cmd: &str) -> anyhow::Result<LspClient> {
+    let cmd_parts: Vec<&str> = lsp_cmd.split_whitespace().collect();
+    if cmd_parts.is_empty() {
+        anyhow::bail!("Cannot start lsp with an empty command!");
+    }
+    let mut lsp = Command::new(cmd_parts[0]);
+    for arg in &cmd_parts[1..] {
+        lsp.arg(arg);
+    }
+    let mut lsp = lsp
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -549,7 +556,7 @@ mod tests {
 
     #[test]
     fn test_initialize_lsp() {
-        let mut lsp = start_lsp().unwrap();
+        let mut lsp = start_lsp("rust-analyzer").unwrap();
         lsp.initialize().unwrap();
         assert!(lsp.initialized);
         lsp.shutdown().unwrap();
@@ -557,7 +564,7 @@ mod tests {
 
     #[test]
     fn test_did_open() {
-        let mut lsp = start_lsp().unwrap();
+        let mut lsp = start_lsp("rust-analyzer").unwrap();
         lsp.initialize().unwrap();
         assert!(lsp.initialized);
         if lsp.initialized {
@@ -571,7 +578,7 @@ mod tests {
 
     #[test]
     pub fn test_hover() {
-        let mut lsp = start_lsp().unwrap();
+        let mut lsp = start_lsp("rust-analyzer").unwrap();
 
         lsp.initialize().unwrap();
         assert!(lsp.initialized);
@@ -631,7 +638,7 @@ fn next_id() -> usize {
 
     #[test]
     fn test_completion() {
-        let mut lsp = start_lsp().unwrap();
+        let mut lsp = start_lsp("rust-analyzer").unwrap();
         lsp.initialize().unwrap();
         assert!(lsp.initialized);
         if lsp.initialized {
@@ -661,7 +668,7 @@ fn next_id() -> usize {
 
     #[test]
     fn test_did_change() {
-        let mut lsp = start_lsp().unwrap();
+        let mut lsp = start_lsp("rust-analyzer").unwrap();
         lsp.initialize().unwrap();
         assert!(lsp.initialized);
         if lsp.initialized {
@@ -692,7 +699,7 @@ fn next_id() -> usize {
 
     #[test]
     fn test_did_save() {
-        let mut lsp = start_lsp().unwrap();
+        let mut lsp = start_lsp("rust-analyzer").unwrap();
         lsp.initialize().unwrap();
         assert!(lsp.initialized);
         if lsp.initialized {
@@ -710,7 +717,7 @@ fn next_id() -> usize {
 
     #[test]
     fn test_get_diagnostics() {
-        let mut lsp = start_lsp().unwrap();
+        let mut lsp = start_lsp("rust-analyzer").unwrap();
         lsp.initialize().unwrap();
         assert!(lsp.initialized);
         if lsp.initialized {
@@ -746,7 +753,7 @@ fn next_id() -> usize {
 
     #[test]
     fn test_did_close() {
-        let mut lsp = start_lsp().unwrap();
+        let mut lsp = start_lsp("rust-analyzer").unwrap();
         lsp.initialize().unwrap();
         assert!(lsp.initialized);
         if lsp.initialized {

--- a/oxid/Cargo.toml
+++ b/oxid/Cargo.toml
@@ -5,9 +5,11 @@ edition = "2024"
 
 [dependencies]
 anyhow.workspace = true
+serde.workspace = true
 
 crossterm = "0.29.0"
 ratatui = { version = "0.29.0", features = ["all-widgets"] }
 ropey = "1.6.1"
+toml = "0.9.6"
 
 oxid-lsp = { path = "../oxid-lsp"}

--- a/oxid/src/app.rs
+++ b/oxid/src/app.rs
@@ -6,6 +6,7 @@ use oxid_lsp::types::{CompletionItem, CompletionList, Diagnostic, Hover};
 use ratatui::widgets::TableState;
 
 use crate::buffer::Buffer;
+use crate::config::Config;
 use crate::events::EventKind;
 use crate::ui::ui;
 
@@ -23,7 +24,7 @@ pub struct App {
     pub current_buf_index: usize,
     pub registers: HashMap<String, String>,
     pub command: Option<String>,
-    pub lsp_client: LspClient,
+    pub lsp_client: Option<LspClient>,
     pub diagnostics: Option<Vec<Diagnostic>>,
     pub show_diagnostics: bool,
     pub completion_list: Option<CompletionList>,
@@ -36,18 +37,37 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(buffers: Vec<Buffer>, tsize_x: usize, tsize_y: usize) -> Self {
-        let mut client = oxid_lsp::client::start_lsp("pyrefly lsp").expect("Could not start LSP");
-        client
-            .initialize()
-            .expect("Could not initialize the LSP Client");
-        let file_path = buffers[0]
+    pub fn new(buffers: Vec<Buffer>, tsize_x: usize, tsize_y: usize, config: Config) -> Self {
+        let file_type = buffers[0]
             .file_path
-            .clone()
-            .expect("Could not extract file path on init");
-        client
-            .did_open(&file_path, buffers[0].file_text.to_string().as_ref())
-            .expect("Could not send initial textDocument/didOpen request.");
+            .as_ref()
+            .expect("First file should have a path")
+            .split(".")
+            .last();
+
+        let mut client = if let Some(ftype) = file_type {
+            config
+                .lsp
+                .iter()
+                .find(|lsp| lsp.filetype == ftype)
+                .map(|lsp| oxid_lsp::client::start_lsp(&lsp.command).expect("Could not start LSP"))
+        } else {
+            None
+        };
+
+        if let Some(lsp_cl) = client.as_mut() {
+            lsp_cl
+                .initialize()
+                .expect("Could not initialize the LSP Client");
+            let file_path = buffers[0]
+                .file_path
+                .clone()
+                .expect("Could not extract file path on init");
+            lsp_cl
+                .did_open(&file_path, buffers[0].file_text.to_string().as_ref())
+                .expect("Could not send initial textDocument/didOpen request.");
+        }
+
         App {
             mode: modes::Mode::Normal,
             tsize_x,

--- a/oxid/src/app.rs
+++ b/oxid/src/app.rs
@@ -37,7 +37,7 @@ pub struct App {
 
 impl App {
     pub fn new(buffers: Vec<Buffer>, tsize_x: usize, tsize_y: usize) -> Self {
-        let mut client = oxid_lsp::client::start_lsp().expect("Could not start LSP");
+        let mut client = oxid_lsp::client::start_lsp("pyrefly lsp").expect("Could not start LSP");
         client
             .initialize()
             .expect("Could not initialize the LSP Client");

--- a/oxid/src/app/commands.rs
+++ b/oxid/src/app/commands.rs
@@ -58,7 +58,9 @@ impl App {
 
     fn quit_current_file(&mut self, terminal: &mut DefaultTerminal) {
         if self.buffers.len() == 1 {
-            _ = self.lsp_client.shutdown();
+            if let Some(lsp) = self.lsp_client.as_mut() {
+                _ = lsp.shutdown();
+            }
             self.quitting = true;
         }
         // -2 because we are gonna remove one more right now, to avoid an extra assign.
@@ -76,7 +78,9 @@ impl App {
     fn quit_all(&mut self, terminal: &mut DefaultTerminal) {
         self.set_mode(terminal, Mode::Normal);
         self.command = None;
-        _ = self.lsp_client.shutdown();
+        if let Some(lsp) = self.lsp_client.as_mut() {
+            _ = lsp.shutdown();
+        }
         self.quitting = true;
     }
     fn save_quit_all(&mut self, terminal: &mut DefaultTerminal) {
@@ -86,7 +90,9 @@ impl App {
             // TODO: Handle this better
             buf.save_file().expect("Could not save all files.");
         });
-        _ = self.lsp_client.shutdown();
+        if let Some(lsp) = self.lsp_client.as_mut() {
+            _ = lsp.shutdown();
+        }
         self.quitting = true;
     }
     fn next_buffer(&mut self, terminal: &mut DefaultTerminal) {

--- a/oxid/src/app/commands.rs
+++ b/oxid/src/app/commands.rs
@@ -35,7 +35,40 @@ impl App {
             Command::PreviousBuffer => self.previous_buffer(terminal),
             Command::OpenFile(path) => self.open_file(path, terminal),
             Command::GoToLine(line) => self.go_to_line(line, terminal),
+            Command::StartLsp(lsp_command) => self.start_lsp(&lsp_command, terminal),
+            Command::StopLsp => self.stop_lsp(terminal),
         }
+    }
+
+    fn start_lsp(&mut self, command: &str, terminal: &mut DefaultTerminal) {
+        if self.lsp_client.is_none() {
+            let client = oxid_lsp::client::start_lsp(command).ok();
+            self.lsp_client = client;
+
+            // We can unwrap because we're garanteed to be Some(LspClient) here.
+            if self.lsp_client.is_some() && self.lsp_client.as_mut().unwrap().initialize().is_ok() {
+                for buffer in &self.buffers {
+                    if let Some(buffer_path) = &buffer.file_path {
+                        _ = self
+                            .lsp_client
+                            .as_mut()
+                            .unwrap()
+                            .did_open(buffer_path, &buffer.file_text.to_string());
+                    }
+                }
+            }
+        }
+        self.set_mode(terminal, Mode::Normal);
+        self.command = None;
+    }
+
+    fn stop_lsp(&mut self, terminal: &mut DefaultTerminal) {
+        if let Some(lsp) = self.lsp_client.as_mut() {
+            _ = lsp.shutdown();
+            self.lsp_client = None;
+        }
+        self.set_mode(terminal, Mode::Normal);
+        self.command = None;
     }
 
     fn save_current_file(&mut self, terminal: &mut DefaultTerminal) {

--- a/oxid/src/app/lsp.rs
+++ b/oxid/src/app/lsp.rs
@@ -6,8 +6,10 @@ use super::App;
 
 impl App {
     pub fn get_diagnostics(&mut self) {
-        if let Some(filepath) = &self.buffers[self.current_buf_index].file_path {
-            match self.lsp_client.get_file_diagnostic(filepath) {
+        if let Some(filepath) = &self.buffers[self.current_buf_index].file_path
+            && let Some(lsp) = self.lsp_client.as_mut()
+        {
+            match lsp.get_file_diagnostic(filepath) {
                 Ok(diag_opt) => match diag_opt {
                     Some(diag_vec) => self.diagnostics = Some(diag_vec),
                     None => self.diagnostics = None,
@@ -18,7 +20,9 @@ impl App {
     }
 
     pub fn hover(&mut self) {
-        if let Some(curr_file_path) = &self.buffers[self.current_buf_index].file_path {
+        if let Some(curr_file_path) = &self.buffers[self.current_buf_index].file_path
+            && let Some(lsp) = self.lsp_client.as_mut()
+        {
             let mut pos = self.buffers[self.current_buf_index]
                 .current_position
                 .clone();
@@ -27,7 +31,7 @@ impl App {
                 .character
                 .saturating_sub(self.buffers[self.current_buf_index].numbar_space);
 
-            match self.lsp_client.hover(
+            match lsp.hover(
                 curr_file_path,
                 Position {
                     line: pos.line,

--- a/oxid/src/app/modes.rs
+++ b/oxid/src/app/modes.rs
@@ -34,11 +34,11 @@ impl App {
                 self.completion_list = None;
                 self.hover = None;
                 self.selected_completion = None;
-                execute!(terminal.backend_mut(), SetCursorStyle::BlinkingBlock).unwrap();
+                execute!(terminal.backend_mut(), SetCursorStyle::BlinkingBlock).unwrap_or_default();
             }
             Mode::Insert => {
                 self.mode = Mode::Insert;
-                execute!(terminal.backend_mut(), SetCursorStyle::BlinkingBar).unwrap();
+                execute!(terminal.backend_mut(), SetCursorStyle::BlinkingBar).unwrap_or_default();
             }
             Mode::Visual => {
                 if self.mode == Mode::Normal {

--- a/oxid/src/command.rs
+++ b/oxid/src/command.rs
@@ -13,6 +13,9 @@ pub enum Command {
     PreviousBuffer, // ":bp"
 
     GoToLine(isize), // ":12"
+
+    StartLsp(String),
+    StopLsp,
 }
 
 impl Command {
@@ -62,6 +65,16 @@ impl FromStr for Command {
                 num if num.parse::<usize>().is_ok() => {
                     Ok(Self::GoToLine(num.parse::<isize>().unwrap_or(-1)))
                 }
+
+                "LspStart" => {
+                    let mut lsp_cmd = String::new();
+                    for cmd_part in cmd_parts {
+                        lsp_cmd.push_str(&format!(" {cmd_part}"));
+                    }
+                    Ok(Self::StartLsp(lsp_cmd))
+                }
+
+                "LspStop" => Ok(Self::StopLsp),
 
                 _ => anyhow::bail!("Unknown command: {cmd}"),
             }

--- a/oxid/src/config.rs
+++ b/oxid/src/config.rs
@@ -1,0 +1,97 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct Config {
+    lsp: Vec<LspConfig>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct LspConfig {
+    filetype: String,
+    command: String,
+}
+
+pub fn read_config_file() -> anyhow::Result<Config> {
+    #[allow(deprecated)]
+    match std::env::home_dir() {
+        Some(dir) => {
+            let cfg_path = dir.join(".config").join("oxid").join("oxid.toml");
+            match std::fs::read_to_string(cfg_path) {
+                Ok(cfg_str) => match toml::from_str::<Config>(&cfg_str) {
+                    Ok(config) => Ok(config),
+                    Err(_) => anyhow::bail!("Could not parse oxid.toml"),
+                },
+                Err(_) => anyhow::bail!("Could not read oxid.toml"),
+            }
+        }
+        None => anyhow::bail!("Could not find $HOME directory."),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs::{self},
+        io::Write,
+        path::PathBuf,
+    };
+
+    use super::*;
+
+    fn config_dir() -> PathBuf {
+        std::env::home_dir().unwrap().join(".config").join("oxid")
+    }
+    fn config_path() -> PathBuf {
+        config_dir().join("oxid.toml")
+    }
+
+    #[test]
+    fn test_read_config_file() {
+        let toml_str = r#"
+            [[lsp]]
+            filetype = "rust"
+            command = "rust-analyzer"
+
+            [[lsp]]
+            filetype = "python"
+            command = "pyrefly lsp"
+
+            [[lsp]]
+            filetype = "gleam"
+            command = "gleam lsp"
+        "#;
+
+        let cfg_dir = config_dir();
+        let cfg_path = config_path();
+
+        fs::create_dir_all(&cfg_dir).unwrap();
+
+        let mut file = fs::File::create(&cfg_path).unwrap();
+        file.write_all(toml_str.as_bytes()).unwrap();
+
+        let cfg = read_config_file().unwrap();
+
+        assert_eq!(
+            cfg,
+            Config {
+                lsp: vec![
+                    LspConfig {
+                        filetype: "rust".to_string(),
+                        command: "rust-analyzer".to_string()
+                    },
+                    LspConfig {
+                        filetype: "python".to_string(),
+                        command: "pyrefly lsp".to_string()
+                    },
+                    LspConfig {
+                        filetype: "gleam".to_string(),
+                        command: "gleam lsp".to_string()
+                    }
+                ]
+            }
+        );
+
+        fs::remove_file(&cfg_path).unwrap();
+        fs::remove_dir_all(&cfg_dir).unwrap();
+    }
+}

--- a/oxid/src/config.rs
+++ b/oxid/src/config.rs
@@ -1,14 +1,14 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Default)]
 pub struct Config {
-    lsp: Vec<LspConfig>,
+    pub lsp: Vec<LspConfig>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Default)]
 pub struct LspConfig {
-    filetype: String,
-    command: String,
+    pub filetype: String,
+    pub command: String,
 }
 
 pub fn read_config_file() -> anyhow::Result<Config> {

--- a/oxid/src/lib.rs
+++ b/oxid/src/lib.rs
@@ -4,3 +4,4 @@ pub mod cli;
 pub mod events;
 pub mod ui;
 pub mod command;
+pub mod config;

--- a/oxid/src/main.rs
+++ b/oxid/src/main.rs
@@ -13,6 +13,7 @@ fn main() -> Result<()> {
 
     let file_path = oxid::cli::get_file_name_arg()?;
     let file_text = Rope::from_reader(BufReader::new(File::open(&file_path)?))?;
+    let config = oxid::config::read_config_file().unwrap_or_default();
 
     let tsize_x = terminal.size()?.width as usize;
     let tsize_y = terminal.size()?.height as usize;
@@ -20,7 +21,7 @@ fn main() -> Result<()> {
     let mut buffers: Vec<Buffer> = Vec::new();
     buffers.push(Buffer::new(Some(file_path), file_text, tsize_x, tsize_y));
 
-    let mut app = App::new(buffers, tsize_x, tsize_y);
+    let mut app = App::new(buffers, tsize_x, tsize_y, config);
     let (event_sender, event_receiver) = channel::<EventKind>();
     std::thread::spawn(move || handle_events(event_sender));
     let result = app.run(event_receiver, &mut terminal);

--- a/oxid/src/ui/editor_view.rs
+++ b/oxid/src/ui/editor_view.rs
@@ -169,8 +169,7 @@ pub fn ui(frame: &mut Frame, app: &App) {
         // let mode = app.mode.to_string();
         // let command = app.command.clone();
         // let dbg_str = format!("MODE: {mode}\n CURRENT COMMAND: {command:#?}");
-        let diags = app.diagnostics.clone();
-        eprintln!("DIAGS: {diags:#?}");
+        // let diags = app.diagnostics.clone();
         let dbg_str = format!("Nothing");
 
         let popup = DebugPopup::default()

--- a/oxid/tests/data/exceptions.py
+++ b/oxid/tests/data/exceptions.py
@@ -1,6 +1,4 @@
-class PipelineDoesNotExists(Exception):asdfasdfas
+class PipelineDoesNotExists(Exception):
     def __init__(self, pipeline_name):
         self.message = f"Pipeline {pipeline_name} does not exists."
         super().__init__(self.message)
-
-patataasdfasdfasdf


### PR DESCRIPTION
As described by #53 , the feature was to implement a simple config file located under `~/.config/oxid/oxid.toml` that contains a table of lsp with their configurations (like filetype to attach and command to run), and the editor would, based on the extension of the initial file, pick an lsp to configure, if available.

This PR also implements the possiblity of not having an LSP attached, either because the config file is not present, because theres's no configured lsp for the file extension or because the user wanted to stop it.

To handle the cases where the user might want to manually start and stop an LSP, the commands `LspStart <lsp_command>` and `LspStop` have also been implemented.

This PR closes #53 .